### PR TITLE
chore: bump litellm version to v1.82.0-stable

### DIFF
--- a/litellm_docker_compose.yaml
+++ b/litellm_docker_compose.yaml
@@ -35,7 +35,7 @@ services:
     command: redis-server --appendonly yes
 
   litellm:
-    image: ghcr.io/berriai/litellm:v1.77.3-stable
+    image: ghcr.io/berriai/litellm:v1.82.0-stable
     container_name: litellm
     platform: linux/amd64
     depends_on:


### PR DESCRIPTION
### What's new

- Bump LiteLLM to `v1.82.0-stable` for local testing