### PR TITLE
feat: error code 5 for upstream 429 resource exhausted

### DIFF
--- a/src/mlpa/core/completions.py
+++ b/src/mlpa/core/completions.py
@@ -10,6 +10,7 @@ from mlpa.core.config import (
     ERROR_CODE_MAX_USERS_REACHED,
     ERROR_CODE_RATE_LIMIT_EXCEEDED,
     ERROR_CODE_REQUEST_TOO_LARGE,
+    ERROR_CODE_UPSTREAM_RATE_LIMIT_EXCEEDED,
     LITELLM_COMPLETION_AUTH_HEADERS,
     LITELLM_COMPLETIONS_URL,
     env,
@@ -25,6 +26,7 @@ from mlpa.core.prometheus_metrics import (
 from mlpa.core.utils import (
     get_or_create_user,
     is_context_window_error,
+    is_litellm_upstream_rate_limit,
     is_rate_limit_error,
     raise_and_log,
 )
@@ -35,6 +37,10 @@ _RATE_LIMIT_REJECTION: dict[int, tuple[PrometheusRejectionReason, str]] = {
         "86400",
     ),
     ERROR_CODE_RATE_LIMIT_EXCEEDED: (PrometheusRejectionReason.RATE_LIMITED, "60"),
+    ERROR_CODE_UPSTREAM_RATE_LIMIT_EXCEEDED: (
+        PrometheusRejectionReason.RATE_LIMITED,
+        "60",
+    ),
 }
 
 
@@ -56,6 +62,10 @@ def _parse_rate_limit_error(error_text: str, user: str) -> int | None:
             return ERROR_CODE_RATE_LIMIT_EXCEEDED
     except (json.JSONDecodeError, AttributeError, UnicodeDecodeError):
         pass
+
+    if is_litellm_upstream_rate_limit(error_text):
+        logger.warning(f"Upstream rate limit exceeded for user {user}: {error_text}")
+        return ERROR_CODE_UPSTREAM_RATE_LIMIT_EXCEEDED
 
     return None
 
@@ -378,6 +388,10 @@ async def get_completion(authorized_chat_request: AuthorizedChatRequest):
     """
     Proxies a non-streaming request to LiteLLM.
     """
+    raise HTTPException(
+        status_code=429,
+        detail={"error": ERROR_CODE_UPSTREAM_RATE_LIMIT_EXCEEDED},
+    )
     start_time = time.perf_counter()
     _record_request_with_tools(authorized_chat_request)
     body = {

--- a/src/mlpa/core/completions.py
+++ b/src/mlpa/core/completions.py
@@ -388,10 +388,6 @@ async def get_completion(authorized_chat_request: AuthorizedChatRequest):
     """
     Proxies a non-streaming request to LiteLLM.
     """
-    raise HTTPException(
-        status_code=429,
-        detail={"error": ERROR_CODE_UPSTREAM_RATE_LIMIT_EXCEEDED},
-    )
     start_time = time.perf_counter()
     _record_request_with_tools(authorized_chat_request)
     body = {

--- a/src/mlpa/core/config.py
+++ b/src/mlpa/core/config.py
@@ -294,6 +294,7 @@ ERROR_CODE_BUDGET_LIMIT_EXCEEDED: int = 1
 ERROR_CODE_RATE_LIMIT_EXCEEDED: int = 2
 ERROR_CODE_REQUEST_TOO_LARGE: int = 3
 ERROR_CODE_MAX_USERS_REACHED: int = 4
+ERROR_CODE_UPSTREAM_RATE_LIMIT_EXCEEDED: int = 5
 
 RATE_LIMIT_ERROR_RESPONSE = {
     429: {
@@ -305,7 +306,7 @@ RATE_LIMIT_ERROR_RESPONSE = {
                     "properties": {
                         "error": {
                             "type": "integer",
-                            "description": "Error code: 1 for budget limit exceeded, 2 for rate limit exceeded",
+                            "description": "Error code: 1 for budget limit exceeded, 2 for rate limit exceeded, 5 for upstream rate limit exceeded",
                         }
                     },
                     "required": ["error"],
@@ -320,6 +321,11 @@ RATE_LIMIT_ERROR_RESPONSE = {
                         "summary": "Rate limit exceeded",
                         "value": {"error": ERROR_CODE_RATE_LIMIT_EXCEEDED},
                         "description": "Rate limit exceeded (TPM/RPM). Check Retry-After header (60 seconds).",
+                    },
+                    "upstream_rate_limit_exceeded": {
+                        "summary": "Upstream rate limit exceeded",
+                        "value": {"error": ERROR_CODE_UPSTREAM_RATE_LIMIT_EXCEEDED},
+                        "description": "Upstream provider rate limit exceeded.",
                     },
                 },
             }

--- a/src/mlpa/core/utils.py
+++ b/src/mlpa/core/utils.py
@@ -134,6 +134,27 @@ def is_rate_limit_error(error_response: dict, keywords: list[str]) -> bool:
     return any(indicator in error_text for indicator in keywords)
 
 
+def is_litellm_upstream_rate_limit(error_text: str) -> bool:
+    """Detect upstream LiteLLM throttling errors for retry."""
+    if not error_text:
+        return False
+    try:
+        error_json = json.loads(error_text)
+        if (
+            error_json.get("status") == "RESOURCE_EXHAUSTED"
+            or error_json.get("type") == "throttling_error"
+        ):
+            return True
+    except Exception:
+        pass
+    normalized = error_text.replace(" ", "").lower()
+    return (
+        "litellm.ratelimiterror" in normalized
+        or '"status":"resource_exhausted"' in normalized
+        or '"type":"throttling_error"' in normalized
+    )
+
+
 def is_context_window_error(error_text: str) -> bool:
     """Check if the error indicates context window exceeded (LiteLLM/providers)."""
     if not error_text:

--- a/src/tests/unit/test_completions.py
+++ b/src/tests/unit/test_completions.py
@@ -12,6 +12,7 @@ from mlpa.core.config import (
     ERROR_CODE_BUDGET_LIMIT_EXCEEDED,
     ERROR_CODE_RATE_LIMIT_EXCEEDED,
     ERROR_CODE_REQUEST_TOO_LARGE,
+    ERROR_CODE_UPSTREAM_RATE_LIMIT_EXCEEDED,
     LITELLM_COMPLETIONS_URL,
     LITELLM_HEADER_ATTEMPTED_FALLBACKS,
     LITELLM_HEADER_ATTEMPTED_RETRIES,
@@ -649,6 +650,42 @@ async def test_get_completion_429_non_rate_limit_error(mocker):
     assert exc_info.value.detail == {"error": "Upstream service returned an error"}
 
 
+async def test_get_completion_upstream_rate_limit_error(mocker):
+    """
+    Tests that a 429 upstream throttling error returns error code 5.
+    """
+    mock_response = MagicMock()
+    mock_response.text = json.dumps(
+        {"status": "RESOURCE_EXHAUSTED", "type": "throttling_error"}
+    )
+    mock_response.status_code = 429
+
+    mock_http_status_error = httpx.HTTPStatusError(
+        "Too Many Requests", request=MagicMock(), response=mock_response
+    )
+    mock_response.raise_for_status.side_effect = mock_http_status_error
+
+    mock_client = AsyncMock()
+    mock_client.post.return_value = mock_response
+    mock_get_client = mocker.patch("mlpa.core.completions.get_http_client")
+    mock_get_client.return_value = mock_client
+
+    mock_metrics = mocker.patch("mlpa.core.completions.metrics")
+    mocker.patch.object(env, "MLPA_DEBUG", False)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await get_completion(SAMPLE_REQUEST)
+
+    assert exc_info.value.status_code == 429
+    assert exc_info.value.detail == {"error": ERROR_CODE_UPSTREAM_RATE_LIMIT_EXCEEDED}
+    mock_metrics.chat_completion_latency.labels.assert_called_once_with(
+        result=PrometheusResult.ERROR,
+        model=SAMPLE_REQUEST.model,
+        service_type=SAMPLE_REQUEST.service_type,
+        purpose=SAMPLE_REQUEST.purpose,
+    )
+
+
 async def test_get_completion_context_window_exceeded(mocker):
     """
     Tests that a 400 error with context window exceeded message returns 413.
@@ -982,6 +1019,37 @@ async def test_stream_completion_429_non_rate_limit_error(
         == b'data: {"code": 429, "error": "Upstream service returned an error"}\n\n'
     )
     mock_logger.error.assert_called_once()
+    mock_metrics.chat_completion_latency.labels.assert_called_once_with(
+        result=PrometheusResult.ERROR,
+        model=SAMPLE_REQUEST.model,
+        service_type=SAMPLE_REQUEST.service_type,
+        purpose=SAMPLE_REQUEST.purpose,
+    )
+
+
+async def test_stream_completion_upstream_rate_limit_error(
+    httpx_mock: HTTPXMock, mocker
+):
+    """
+    Tests that a 429 upstream throttling error returns error code 5.
+    """
+    error_response = json.dumps(
+        {"status": "RESOURCE_EXHAUSTED", "type": "throttling_error"}
+    )
+    httpx_mock.add_response(
+        method="POST",
+        url=LITELLM_COMPLETIONS_URL,
+        content=error_response.encode(),
+        status_code=429,
+    )
+
+    mock_metrics = mocker.patch("mlpa.core.completions.metrics")
+
+    received_chunks = [chunk async for chunk in stream_completion(SAMPLE_REQUEST)]
+
+    assert received_chunks == [
+        f'data: {{"error": {ERROR_CODE_UPSTREAM_RATE_LIMIT_EXCEEDED}}}\n\n'.encode()
+    ]
     mock_metrics.chat_completion_latency.labels.assert_called_once_with(
         result=PrometheusResult.ERROR,
         model=SAMPLE_REQUEST.model,


### PR DESCRIPTION
## What's new

- Convert upstream 429 `resource exhausted` errors to `error: 5` code