### PR TITLE
chore: refactor user capacity table

### DIFF
--- a/alembic/script.py.mako
+++ b/alembic/script.py.mako
@@ -1,0 +1,24 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+# revision identifiers, used by Alembic.
+revision = ${repr(up_revision)}
+down_revision = ${repr(down_revision)}
+branch_labels = ${repr(branch_labels)}
+depends_on = ${repr(depends_on)}
+
+
+def upgrade() -> None:
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    ${downgrades if downgrades else "pass"}

--- a/alembic/versions/919c4d382c42_user_capacity.py
+++ b/alembic/versions/919c4d382c42_user_capacity.py
@@ -1,0 +1,44 @@
+"""user capacity
+
+Revision ID: 919c4d382c42
+Revises: 5b4ed32c7b2b
+Create Date: 2026-04-13 13:06:54.729440
+
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "919c4d382c42"
+down_revision = "5b4ed32c7b2b"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS mlpa_user_capacity (
+            id SMALLINT PRIMARY KEY CHECK (id = 1),
+            max_identities BIGINT NOT NULL CHECK (max_identities >= 0),
+            current_identities BIGINT NOT NULL CHECK (current_identities >= 0),
+            updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+        );
+        """
+    )
+
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS mlpa_user_capacity_identities (
+            base_identity TEXT PRIMARY KEY,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+        );
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP TABLE IF EXISTS mlpa_user_capacity_identities")
+    op.execute("DROP TABLE IF EXISTS mlpa_user_capacity")

--- a/scripts/migrate-app-attest-database-local.sh
+++ b/scripts/migrate-app-attest-database-local.sh
@@ -14,8 +14,14 @@ DB_PASSWORD=${DB_PASSWORD:-litellm}
 DB_HOST=${DB_HOST:-localhost}
 DB_PORT=${DB_PORT:-5432}
 APP_ATTEST_DB_NAME=${APP_ATTEST_DB_NAME:-app_attest}
+MLPA_MAX_SIGNED_IN_USERS=${MLPA_MAX_SIGNED_IN_USERS:-100}
 
 set -eo pipefail
+
+export PGHOST="${DB_HOST}"
+export PGPORT="${DB_PORT}"
+export PGUSER="${DB_USERNAME}"
+export PGPASSWORD="${DB_PASSWORD}"
 
 CONTAINER_NAME="litellm_postgres"
 
@@ -50,5 +56,14 @@ echo "[mlpa-appattest-migrate-local] Target (password redacted): postgresql://${
 
 echo "[mlpa-appattest-migrate-local] Running Alembic upgrade head (Alembic messages follow)..."
 uv run alembic --raiseerr -c alembic.ini -x sqlalchemy.url="${APP_ATTEST_DATABASE_URL}" upgrade head 2>&1
+
+echo "[mlpa-appattest-migrate] Seeding mlpa_user_capacity max_identities=${MLPA_MAX_SIGNED_IN_USERS}"
+psql -d "${APP_ATTEST_DB_NAME}" -c "
+  INSERT INTO mlpa_user_capacity (id, max_identities, current_identities)
+  VALUES (1, ${MLPA_MAX_SIGNED_IN_USERS}, 0)
+  ON CONFLICT (id) DO UPDATE SET
+    max_identities = EXCLUDED.max_identities,
+    updated_at = NOW();
+"
 
 echo "✅ Migrations completed successfully"

--- a/scripts/migrate-app-attest-database.sh
+++ b/scripts/migrate-app-attest-database.sh
@@ -6,6 +6,7 @@ set -euo pipefail
 : "${DB_USERNAME:?DB_USERNAME is required}"
 : "${DB_PASSWORD:?DB_PASSWORD is required}"
 : "${APP_ATTEST_DB_NAME:?APP_ATTEST_DB_NAME is required}"
+: "${MLPA_MAX_SIGNED_IN_USERS:?MLPA_MAX_SIGNED_IN_USERS is required}"
 
 export PGHOST="${DB_HOST}"
 export PGPORT="${DB_PORT}"
@@ -27,5 +28,14 @@ fi
 
 echo "[mlpa-appattest-migrate] Running Alembic upgrade head (Alembic messages follow)..."
 alembic --raiseerr -c alembic.ini -x sqlalchemy.url="${APP_ATTEST_DATABASE_URL}" upgrade head 2>&1
+
+echo "[mlpa-appattest-migrate] Seeding mlpa_user_capacity max_identities=${MLPA_MAX_SIGNED_IN_USERS}"
+psql -d "${APP_ATTEST_DB_NAME}" -c "
+  INSERT INTO mlpa_user_capacity (id, max_identities, current_identities)
+  VALUES (1, ${MLPA_MAX_SIGNED_IN_USERS}, 0)
+  ON CONFLICT (id) DO UPDATE SET
+    max_identities = EXCLUDED.max_identities,
+    updated_at = NOW();
+"
 
 echo "[mlpa-appattest-migrate] Finished successfully."

--- a/src/mlpa/core/pg_services/app_attest_pg_service.py
+++ b/src/mlpa/core/pg_services/app_attest_pg_service.py
@@ -2,12 +2,14 @@ from fastapi import HTTPException
 
 from mlpa.core.config import env
 from mlpa.core.logger import logger
+from mlpa.core.pg_services.litellm_pg_service import LiteLLMPGService
 from mlpa.core.pg_services.pg_service import PGService
 
 
 class AppAttestPGService(PGService):
-    def __init__(self):
+    def __init__(self, litellm_pg: LiteLLMPGService):
         super().__init__(env.APP_ATTEST_DB_NAME)
+        self.litellm_pg = litellm_pg
 
     # Challenges #
     async def store_challenge(self, key_id_b64: str, challenge: str):
@@ -114,9 +116,7 @@ class AppAttestPGService(PGService):
                     """
                     INSERT INTO mlpa_user_capacity (id, max_identities, current_identities)
                     VALUES (1, $1, 0)
-                    ON CONFLICT (id) DO UPDATE SET
-                        max_identities = EXCLUDED.max_identities,
-                        updated_at = NOW()
+                    ON CONFLICT (id) DO NOTHING
                     """,
                     env.MLPA_MAX_SIGNED_IN_USERS,
                 )
@@ -126,13 +126,21 @@ class AppAttestPGService(PGService):
                 await conn.fetchrow(
                     "SELECT 1 FROM mlpa_user_capacity WHERE id = 1 FOR UPDATE"
                 )
+                await conn.execute(
+                    """
+                    UPDATE mlpa_user_capacity
+                    SET max_identities = $1,
+                        updated_at = NOW()
+                    WHERE id = 1
+                    """,
+                    env.MLPA_MAX_SIGNED_IN_USERS,
+                )
 
                 # Rebuild claims from LiteLLM so the counter matches reality after deletes
                 # or manual DB edits. Blocked rows still count toward capacity.
                 await conn.execute("DELETE FROM mlpa_user_capacity_identities")
-                from mlpa.core.pg_services.services import litellm_pg
 
-                base_identities = await litellm_pg.list_managed_base_identities(
+                base_identities = await self.litellm_pg.list_managed_base_identities(
                     managed_service_types
                 )
                 if base_identities:
@@ -260,9 +268,7 @@ class AppAttestPGService(PGService):
                 if not claimed:
                     return
 
-                from mlpa.core.pg_services.services import litellm_pg
-
-                has_managed_user_rows = await litellm_pg.has_managed_user_rows(
+                has_managed_user_rows = await self.litellm_pg.has_managed_user_rows(
                     base_identity,
                     managed_service_types,
                 )

--- a/src/mlpa/core/pg_services/app_attest_pg_service.py
+++ b/src/mlpa/core/pg_services/app_attest_pg_service.py
@@ -1,3 +1,5 @@
+from fastapi import HTTPException
+
 from mlpa.core.config import env
 from mlpa.core.logger import logger
 from mlpa.core.pg_services.pg_service import PGService
@@ -95,3 +97,234 @@ class AppAttestPGService(PGService):
             )
         except Exception as e:
             logger.error(f"Error deleting key: {e}")
+
+    async def ensure_capacity_state(self) -> None:
+        """
+        Ensure the singleton capacity row and base-identity claim table exist.
+
+        Reconciles the claim table with current LiteLLM end-user rows for
+        cap-managed service types on every startup (blocked rows included) so
+        the counter reflects reality after external writes and config changes.
+        """
+        managed_service_types = list(env.MLPA_CAPPED_SERVICE_TYPES)
+
+        async with self.pool.acquire() as conn:
+            async with conn.transaction():
+                await conn.execute(
+                    """
+                    INSERT INTO mlpa_user_capacity (id, max_identities, current_identities)
+                    VALUES (1, $1, 0)
+                    ON CONFLICT (id) DO UPDATE SET
+                        max_identities = EXCLUDED.max_identities,
+                        updated_at = NOW()
+                    """,
+                    env.MLPA_MAX_SIGNED_IN_USERS,
+                )
+
+                # Serialize seeding and reconciliation so concurrent app startups
+                # do not race on the claim table.
+                await conn.fetchrow(
+                    "SELECT 1 FROM mlpa_user_capacity WHERE id = 1 FOR UPDATE"
+                )
+
+                # Rebuild claims from LiteLLM so the counter matches reality after deletes
+                # or manual DB edits. Blocked rows still count toward capacity.
+                await conn.execute("DELETE FROM mlpa_user_capacity_identities")
+                from mlpa.core.pg_services.services import litellm_pg
+
+                base_identities = await litellm_pg.list_managed_base_identities(
+                    managed_service_types
+                )
+                if base_identities:
+                    await conn.executemany(
+                        """
+                        INSERT INTO mlpa_user_capacity_identities (base_identity)
+                        VALUES ($1)
+                        """,
+                        [(base_identity,) for base_identity in base_identities],
+                    )
+
+                seeded_claims = await conn.fetchval(
+                    "SELECT COUNT(*) FROM mlpa_user_capacity_identities"
+                )
+                await conn.execute(
+                    """
+                    UPDATE mlpa_user_capacity
+                    SET current_identities = $1,
+                        updated_at = NOW()
+                    WHERE id = 1
+                    """,
+                    seeded_claims,
+                )
+
+    async def admit_managed_base_identity(
+        self, base_identity: str
+    ) -> tuple[bool, bool]:
+        """
+        Admit a cap-managed base identity.
+
+        Returns:
+          (admitted, newly_claimed)
+        """
+        if not env.MLPA_ENFORCE_SIGNIN_CAP:
+            return True, False
+
+        async with self.pool.acquire() as conn:
+            async with conn.transaction():
+                await conn.execute(
+                    f"SET LOCAL lock_timeout = '{env.MLPA_ADMISSION_LOCK_TIMEOUT_MS}ms'"
+                )
+                capacity_row = await conn.fetchrow(
+                    """
+                    SELECT max_identities, current_identities
+                    FROM mlpa_user_capacity
+                    WHERE id = 1
+                    FOR UPDATE
+                    """
+                )
+                if capacity_row is None:
+                    raise HTTPException(
+                        status_code=500,
+                        detail="Capacity state not initialized",
+                    )
+
+                already_claimed = await conn.fetchval(
+                    """
+                    SELECT 1
+                    FROM mlpa_user_capacity_identities
+                    WHERE base_identity = $1
+                    """,
+                    base_identity,
+                )
+                if already_claimed:
+                    return True, False
+
+                max_identities = int(capacity_row["max_identities"])
+                current_identities = int(capacity_row["current_identities"])
+                if current_identities >= max_identities:
+                    return False, False
+
+                await conn.execute(
+                    """
+                    INSERT INTO mlpa_user_capacity_identities (base_identity)
+                    VALUES ($1)
+                    """,
+                    base_identity,
+                )
+                await conn.execute(
+                    """
+                    UPDATE mlpa_user_capacity
+                    SET current_identities = current_identities + 1,
+                        updated_at = NOW()
+                    WHERE id = 1
+                    """
+                )
+                return True, True
+
+    async def maybe_release_managed_base_identity_if_no_managed_users(
+        self, base_identity: str
+    ) -> None:
+        """
+        Release a claim if the base identity has no cap-managed LiteLLM end-user
+        rows (blocked rows still count — delete/unblock+delete in LiteLLM to release).
+        """
+        if not env.MLPA_ENFORCE_SIGNIN_CAP:
+            return
+
+        managed_service_types = list(env.MLPA_CAPPED_SERVICE_TYPES)
+
+        async with self.pool.acquire() as conn:
+            async with conn.transaction():
+                await conn.execute(
+                    f"SET LOCAL lock_timeout = '{env.MLPA_ADMISSION_LOCK_TIMEOUT_MS}ms'"
+                )
+                capacity_row = await conn.fetchrow(
+                    """
+                    SELECT max_identities, current_identities
+                    FROM mlpa_user_capacity
+                    WHERE id = 1
+                    FOR UPDATE
+                    """
+                )
+                if capacity_row is None:
+                    return
+
+                claimed = await conn.fetchval(
+                    """
+                    SELECT 1
+                    FROM mlpa_user_capacity_identities
+                    WHERE base_identity = $1
+                    """,
+                    base_identity,
+                )
+                if not claimed:
+                    return
+
+                from mlpa.core.pg_services.services import litellm_pg
+
+                has_managed_user_rows = await litellm_pg.has_managed_user_rows(
+                    base_identity,
+                    managed_service_types,
+                )
+                if has_managed_user_rows:
+                    return
+
+                await conn.execute(
+                    """
+                    DELETE FROM mlpa_user_capacity_identities
+                    WHERE base_identity = $1
+                    """,
+                    base_identity,
+                )
+                await conn.execute(
+                    """
+                    UPDATE mlpa_user_capacity
+                    SET current_identities = GREATEST(current_identities - 1, 0),
+                        updated_at = NOW()
+                    WHERE id = 1
+                    """
+                )
+
+    async def get_signup_cap_status(self) -> dict:
+        """
+        Managed signup capacity: distinct base identities with any capped service type row.
+        Mirrors mlpa_user_capacity / mlpa_user_capacity_identities (updated at startup and on admit/release).
+        """
+        try:
+            row = await self.pool.fetchrow(
+                """
+                    SELECT max_identities, current_identities, updated_at
+                    FROM mlpa_user_capacity
+                    WHERE id = 1
+                    """
+            )
+        except Exception as e:
+            logger.error(f"Error reading signup cap state: {e}")
+            raise HTTPException(
+                status_code=500,
+                detail={"error": "Error reading signup cap state"},
+            )
+
+        if row is None:
+            return {
+                "enforce_signin_cap": env.MLPA_ENFORCE_SIGNIN_CAP,
+                "capped_service_types": sorted(env.MLPA_CAPPED_SERVICE_TYPES),
+                "max_signed_in_users": env.MLPA_MAX_SIGNED_IN_USERS,
+                "current_managed_identities": None,
+                "slots_remaining": None,
+                "capacity_updated_at": None,
+                "capacity_row_missing": True,
+            }
+
+        max_i = int(row["max_identities"])
+        cur = int(row["current_identities"])
+        updated_at = row["updated_at"]
+        return {
+            "enforce_signin_cap": env.MLPA_ENFORCE_SIGNIN_CAP,
+            "capped_service_types": sorted(env.MLPA_CAPPED_SERVICE_TYPES),
+            "max_signed_in_users": max_i,
+            "current_managed_identities": cur,
+            "slots_remaining": max(0, max_i - cur),
+            "capacity_updated_at": updated_at.isoformat() if updated_at else None,
+            "capacity_row_missing": False,
+        }

--- a/src/mlpa/core/pg_services/litellm_pg_service.py
+++ b/src/mlpa/core/pg_services/litellm_pg_service.py
@@ -136,49 +136,44 @@ class LiteLLMPGService(PGService):
                 detail={"error": "Error counting users by service type"},
             )
 
-    async def get_signup_cap_status(self) -> dict:
+    async def list_managed_base_identities(
+        self, managed_service_types: list[str]
+    ) -> list[str]:
         """
-        Managed signup capacity: distinct base identities with any capped service type row.
-        Mirrors mlpa_user_capacity / mlpa_user_capacity_identities (updated at startup and on admit/release).
+        Return distinct base identities for cap-managed service types.
         """
-        try:
-            row = await self.pool.fetchrow(
-                """
-                SELECT max_identities, current_identities, updated_at
-                FROM mlpa_user_capacity
-                WHERE id = 1
-                """
-            )
-        except Exception as e:
-            logger.error(f"Error reading signup cap state: {e}")
-            raise HTTPException(
-                status_code=500,
-                detail={"error": "Error reading signup cap state"},
-            )
+        rows = await self.pool.fetch(
+            """
+            SELECT DISTINCT split_part(user_id, ':', 1) AS base_identity
+            FROM "LiteLLM_EndUserTable"
+            WHERE position(':' in user_id) > 0
+              AND split_part(user_id, ':', 2) = ANY($1::text[])
+            """,
+            managed_service_types,
+        )
+        return [row["base_identity"] for row in rows if row.get("base_identity")]
 
-        if row is None:
-            return {
-                "enforce_signin_cap": env.MLPA_ENFORCE_SIGNIN_CAP,
-                "capped_service_types": sorted(env.MLPA_CAPPED_SERVICE_TYPES),
-                "max_signed_in_users": env.MLPA_MAX_SIGNED_IN_USERS,
-                "current_managed_identities": None,
-                "slots_remaining": None,
-                "capacity_updated_at": None,
-                "capacity_row_missing": True,
-            }
-
-        max_i = int(row["max_identities"])
-        cur = int(row["current_identities"])
-        updated_at = row["updated_at"]
-        return {
-            "enforce_signin_cap": env.MLPA_ENFORCE_SIGNIN_CAP,
-            "capped_service_types": sorted(env.MLPA_CAPPED_SERVICE_TYPES),
-            "max_signed_in_users": max_i,
-            "current_managed_identities": cur,
-            "slots_remaining": max(0, max_i - cur),
-            "capacity_updated_at": updated_at.isoformat() if updated_at else None,
-            "capacity_row_missing": False,
-        }
+    async def has_managed_user_rows(
+        self, base_identity: str, managed_service_types: list[str]
+    ) -> bool:
+        """
+        Return True if the base identity has any cap-managed LiteLLM end-user rows.
+        """
+        return bool(
+            await self.pool.fetchval(
+                """
+                SELECT EXISTS(
+                    SELECT 1
+                    FROM "LiteLLM_EndUserTable"
+                    WHERE position(':' in user_id) > 0
+                      AND split_part(user_id, ':', 1) = $1
+                      AND split_part(user_id, ':', 2) = ANY($2::text[])
+                )
+                """,
+                base_identity,
+                managed_service_types,
+            )
+        )
 
     async def create_budget(self):
         """
@@ -220,214 +215,4 @@ class LiteLLMPGService(PGService):
             except Exception as e:
                 logger.error(
                     f"Error creating budget for service_type={service_type}, budget_id={budget_config.get('budget_id', 'unknown')}: {e}"
-                )
-
-    async def ensure_capacity_state(self) -> None:
-        """
-        Ensure the singleton capacity row and base-identity claim table exist.
-
-        Reconciles the claim table with current LiteLLM end-user rows for
-        cap-managed service types on every startup (blocked rows included) so
-        the counter reflects reality after external writes and config changes.
-        """
-        managed_service_types = list(env.MLPA_CAPPED_SERVICE_TYPES)
-
-        async with self.pool.acquire() as conn:
-            async with conn.transaction():
-                await conn.execute(
-                    """
-                    CREATE TABLE IF NOT EXISTS mlpa_user_capacity (
-                        id SMALLINT PRIMARY KEY CHECK (id = 1),
-                        max_identities BIGINT NOT NULL CHECK (max_identities >= 0),
-                        current_identities BIGINT NOT NULL CHECK (current_identities >= 0),
-                        updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
-                    );
-                    """
-                )
-                await conn.execute(
-                    """
-                    CREATE TABLE IF NOT EXISTS mlpa_user_capacity_identities (
-                        base_identity TEXT PRIMARY KEY,
-                        created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
-                    );
-                    """
-                )
-
-                await conn.execute(
-                    """
-                    INSERT INTO mlpa_user_capacity (id, max_identities, current_identities)
-                    VALUES (1, $1, 0)
-                    ON CONFLICT (id) DO UPDATE SET
-                        max_identities = EXCLUDED.max_identities,
-                        updated_at = NOW()
-                    """,
-                    env.MLPA_MAX_SIGNED_IN_USERS,
-                )
-
-                # Serialize seeding and reconciliation so concurrent app startups
-                # do not race on the claim table.
-                await conn.fetchrow(
-                    "SELECT 1 FROM mlpa_user_capacity WHERE id = 1 FOR UPDATE"
-                )
-
-                # Rebuild claims from LiteLLM so the counter matches reality after deletes
-                # or manual DB edits. Blocked rows still count toward capacity.
-                await conn.execute("DELETE FROM mlpa_user_capacity_identities")
-                await conn.execute(
-                    """
-                    INSERT INTO mlpa_user_capacity_identities (base_identity)
-                    SELECT DISTINCT split_part(user_id, ':', 1) AS base_identity
-                    FROM "LiteLLM_EndUserTable"
-                    WHERE position(':' in user_id) > 0
-                      AND split_part(user_id, ':', 2) = ANY($1::text[])
-                    """,
-                    managed_service_types,
-                )
-
-                seeded_claims = await conn.fetchval(
-                    "SELECT COUNT(*) FROM mlpa_user_capacity_identities"
-                )
-                await conn.execute(
-                    """
-                    UPDATE mlpa_user_capacity
-                    SET current_identities = $1,
-                        updated_at = NOW()
-                    WHERE id = 1
-                    """,
-                    seeded_claims,
-                )
-
-    async def admit_managed_base_identity(
-        self, base_identity: str
-    ) -> tuple[bool, bool]:
-        """
-        Admit a cap-managed base identity.
-
-        Returns:
-          (admitted, newly_claimed)
-        """
-        if not env.MLPA_ENFORCE_SIGNIN_CAP:
-            return True, False
-
-        async with self.pool.acquire() as conn:
-            async with conn.transaction():
-                await conn.execute(
-                    f"SET LOCAL lock_timeout = '{env.MLPA_ADMISSION_LOCK_TIMEOUT_MS}ms'"
-                )
-                capacity_row = await conn.fetchrow(
-                    """
-                    SELECT max_identities, current_identities
-                    FROM mlpa_user_capacity
-                    WHERE id = 1
-                    FOR UPDATE
-                    """
-                )
-                if capacity_row is None:
-                    raise HTTPException(
-                        status_code=500,
-                        detail="Capacity state not initialized",
-                    )
-
-                already_claimed = await conn.fetchval(
-                    """
-                    SELECT 1
-                    FROM mlpa_user_capacity_identities
-                    WHERE base_identity = $1
-                    """,
-                    base_identity,
-                )
-                if already_claimed:
-                    return True, False
-
-                max_identities = int(capacity_row["max_identities"])
-                current_identities = int(capacity_row["current_identities"])
-                if current_identities >= max_identities:
-                    return False, False
-
-                await conn.execute(
-                    """
-                    INSERT INTO mlpa_user_capacity_identities (base_identity)
-                    VALUES ($1)
-                    """,
-                    base_identity,
-                )
-                await conn.execute(
-                    """
-                    UPDATE mlpa_user_capacity
-                    SET current_identities = current_identities + 1,
-                        updated_at = NOW()
-                    WHERE id = 1
-                    """
-                )
-                return True, True
-
-    async def maybe_release_managed_base_identity_if_no_managed_users(
-        self, base_identity: str
-    ) -> None:
-        """
-        Release a claim if the base identity has no cap-managed LiteLLM end-user
-        rows (blocked rows still count — delete/unblock+delete in LiteLLM to release).
-        """
-        if not env.MLPA_ENFORCE_SIGNIN_CAP:
-            return
-
-        managed_service_types = list(env.MLPA_CAPPED_SERVICE_TYPES)
-
-        async with self.pool.acquire() as conn:
-            async with conn.transaction():
-                await conn.execute(
-                    f"SET LOCAL lock_timeout = '{env.MLPA_ADMISSION_LOCK_TIMEOUT_MS}ms'"
-                )
-                capacity_row = await conn.fetchrow(
-                    """
-                    SELECT max_identities, current_identities
-                    FROM mlpa_user_capacity
-                    WHERE id = 1
-                    FOR UPDATE
-                    """
-                )
-                if capacity_row is None:
-                    return
-
-                claimed = await conn.fetchval(
-                    """
-                    SELECT 1
-                    FROM mlpa_user_capacity_identities
-                    WHERE base_identity = $1
-                    """,
-                    base_identity,
-                )
-                if not claimed:
-                    return
-
-                has_managed_user_rows = await conn.fetchval(
-                    """
-                    SELECT EXISTS(
-                        SELECT 1
-                        FROM "LiteLLM_EndUserTable"
-                        WHERE position(':' in user_id) > 0
-                          AND split_part(user_id, ':', 1) = $1
-                          AND split_part(user_id, ':', 2) = ANY($2::text[])
-                    )
-                    """,
-                    base_identity,
-                    managed_service_types,
-                )
-                if has_managed_user_rows:
-                    return
-
-                await conn.execute(
-                    """
-                    DELETE FROM mlpa_user_capacity_identities
-                    WHERE base_identity = $1
-                    """,
-                    base_identity,
-                )
-                await conn.execute(
-                    """
-                    UPDATE mlpa_user_capacity
-                    SET current_identities = GREATEST(current_identities - 1, 0),
-                        updated_at = NOW()
-                    WHERE id = 1
-                    """
                 )

--- a/src/mlpa/core/pg_services/services.py
+++ b/src/mlpa/core/pg_services/services.py
@@ -2,4 +2,4 @@ from mlpa.core.pg_services.app_attest_pg_service import AppAttestPGService
 from mlpa.core.pg_services.litellm_pg_service import LiteLLMPGService
 
 litellm_pg = LiteLLMPGService()
-app_attest_pg = AppAttestPGService()
+app_attest_pg = AppAttestPGService(litellm_pg)

--- a/src/mlpa/core/routers/user/user.py
+++ b/src/mlpa/core/routers/user/user.py
@@ -8,7 +8,7 @@ from mlpa.core.classes import BudgetUpdatePayload
 from mlpa.core.config import LITELLM_MASTER_AUTH_HEADERS, env
 from mlpa.core.http_client import get_http_client
 from mlpa.core.logger import logger
-from mlpa.core.pg_services.services import litellm_pg
+from mlpa.core.pg_services.services import app_attest_pg, litellm_pg
 from mlpa.core.utils import raise_and_log
 
 router = APIRouter()
@@ -65,7 +65,7 @@ async def signup_cap_status(
     _: Annotated[None, Depends(require_ui_access_key)] = None,
 ):
     """Managed signup capacity for capped service types (MLPA_UI_ACCESS_KEY)."""
-    return await litellm_pg.get_signup_cap_status()
+    return await app_attest_pg.get_signup_cap_status()
 
 
 @router.get("/{user_id}", tags=["User"])

--- a/src/mlpa/core/utils.py
+++ b/src/mlpa/core/utils.py
@@ -17,7 +17,7 @@ from mlpa.core.config import (
 )
 from mlpa.core.http_client import get_http_client
 from mlpa.core.logger import logger
-from mlpa.core.pg_services.services import litellm_pg
+from mlpa.core.pg_services.services import app_attest_pg, litellm_pg
 from mlpa.core.prometheus_metrics import PrometheusResult, metrics
 
 
@@ -53,7 +53,10 @@ async def get_or_create_user(user_id: str):
                 env.MLPA_ENFORCE_SIGNIN_CAP
                 and service_type in env.MLPA_CAPPED_SERVICE_TYPES
             ):
-                admitted, newly_claimed = await litellm_pg.admit_managed_base_identity(
+                (
+                    admitted,
+                    newly_claimed,
+                ) = await app_attest_pg.admit_managed_base_identity(
                     base_identity=base_identity
                 )
                 if not admitted:
@@ -79,7 +82,7 @@ async def get_or_create_user(user_id: str):
                 # Admission may have succeeded but LiteLLM user creation did not.
                 # Release the reserved slot to avoid claim/cap drift.
                 if claimed_new_identity:
-                    await litellm_pg.maybe_release_managed_base_identity_if_no_managed_users(
+                    await app_attest_pg.maybe_release_managed_base_identity_if_no_managed_users(
                         base_identity=base_identity
                     )
                 raise HTTPException(
@@ -94,10 +97,8 @@ async def get_or_create_user(user_id: str):
     except Exception as e:
         if claimed_new_identity:
             try:
-                await (
-                    litellm_pg.maybe_release_managed_base_identity_if_no_managed_users(
-                        base_identity=base_identity
-                    )
+                await app_attest_pg.maybe_release_managed_base_identity_if_no_managed_users(
+                    base_identity=base_identity
                 )
             except Exception as release_e:
                 logger.error(

--- a/src/mlpa/run.py
+++ b/src/mlpa/run.py
@@ -70,7 +70,7 @@ async def lifespan(app: FastAPI):
         app_attest_connected = True
 
         await litellm_pg.create_budget()
-        await litellm_pg.ensure_capacity_state()
+        await app_attest_pg.ensure_capacity_state()
 
         yield
     finally:

--- a/src/tests/integration/conftest.py
+++ b/src/tests/integration/conftest.py
@@ -27,6 +27,7 @@ def mocked_client_integration(mocker, use_real_get_or_create_user):
     """
     mock_app_attest_pg = MockAppAttestPGService()
     mock_litellm_pg = MockLiteLLMPGService()
+    mock_app_attest_pg.litellm_pg = mock_litellm_pg
     mock_fxa_client = MockFxAService(
         "test-client-id", "test-client-secret", "https://test-fxa.com"
     )
@@ -39,6 +40,8 @@ def mocked_client_integration(mocker, use_real_get_or_create_user):
         "mlpa.core.routers.appattest.appattest.app_attest_pg", mock_app_attest_pg
     )
     mocker.patch("mlpa.core.routers.health.health.app_attest_pg", mock_app_attest_pg)
+    mocker.patch("mlpa.core.routers.user.user.app_attest_pg", mock_app_attest_pg)
+    mocker.patch("mlpa.core.utils.app_attest_pg", mock_app_attest_pg)
     mocker.patch("mlpa.run.litellm_pg", mock_litellm_pg)
     mocker.patch("mlpa.core.routers.health.health.litellm_pg", mock_litellm_pg)
     mocker.patch("mlpa.core.utils.litellm_pg", mock_litellm_pg)
@@ -86,16 +89,20 @@ def mocked_client_integration(mocker, use_real_get_or_create_user):
     if not use_real_get_or_create_user:
         mocker.patch(
             "mlpa.run.get_or_create_user_for_completion",
-            lambda user_id, req: mock_get_or_create_user(mock_litellm_pg, user_id),
+            lambda user_id, req: mock_get_or_create_user(
+                mock_litellm_pg, mock_app_attest_pg, user_id
+            ),
         )
         mocker.patch(
             "mlpa.core.routers.mock.mock.get_or_create_user_for_completion",
-            lambda user_id, req: mock_get_or_create_user(mock_litellm_pg, user_id),
+            lambda user_id, req: mock_get_or_create_user(
+                mock_litellm_pg, mock_app_attest_pg, user_id
+            ),
         )
         mocker.patch(
             "mlpa.core.routers.mock.mock.get_or_create_user",
             lambda *args, **kwargs: mock_get_or_create_user(
-                mock_litellm_pg, *args, **kwargs
+                mock_litellm_pg, mock_app_attest_pg, *args, **kwargs
             ),
         )
     with TestClient(main_app.app) as client:

--- a/src/tests/integration/conftest.py
+++ b/src/tests/integration/conftest.py
@@ -25,9 +25,8 @@ def mocked_client_integration(mocker, use_real_get_or_create_user):
     """
     This fixture mocks the database services and provides a TestClient.
     """
-    mock_app_attest_pg = MockAppAttestPGService()
     mock_litellm_pg = MockLiteLLMPGService()
-    mock_app_attest_pg.litellm_pg = mock_litellm_pg
+    mock_app_attest_pg = MockAppAttestPGService(mock_litellm_pg)
     mock_fxa_client = MockFxAService(
         "test-client-id", "test-client-secret", "https://test-fxa.com"
     )

--- a/src/tests/integration/test_app_attest.py
+++ b/src/tests/integration/test_app_attest.py
@@ -24,7 +24,7 @@ from tests.integration.appattest_helpers import (
     make_jwt,
     patch_apple_config_capture_app_id,
 )
-from tests.mocks import MockAppAttestPGService
+from tests.mocks import MockAppAttestPGService, MockLiteLLMPGService
 
 sample_chat_request = SAMPLE_CHAT_REQUEST.model_dump(exclude_unset=True)
 jwt_secret = "secret"
@@ -265,7 +265,7 @@ async def test_assert_uses_bundle_id_from_jwt(mocker, mocked_client_integration)
     )
 
     # Seed a fake key so verify_assert gets past the public-key lookup
-    mock_pg = MockAppAttestPGService()
+    mock_pg = MockAppAttestPGService(MockLiteLLMPGService())
     await mock_pg.store_key(TEST_KEY_ID_B64, "fake_pem", counter=0)
     mocker.patch("mlpa.core.routers.appattest.appattest.app_attest_pg", mock_pg)
 
@@ -327,7 +327,7 @@ def _build_fake_assertion(counter: int) -> bytes:
 
 
 async def test_verify_assert_rejects_non_monotonic_counter(mocker):
-    mock_pg = MockAppAttestPGService()
+    mock_pg = MockAppAttestPGService(MockLiteLLMPGService())
     mocker.patch("mlpa.core.routers.appattest.appattest.app_attest_pg", mock_pg)
 
     private_key = ec.generate_private_key(ec.SECP256R1())
@@ -352,7 +352,7 @@ async def test_verify_assert_rejects_non_monotonic_counter(mocker):
 
 
 async def test_verify_assert_succeeds_and_updates_counter(mocker):
-    mock_pg = MockAppAttestPGService()
+    mock_pg = MockAppAttestPGService(MockLiteLLMPGService())
     mocker.patch("mlpa.core.routers.appattest.appattest.app_attest_pg", mock_pg)
 
     private_key = ec.generate_private_key(ec.SECP256R1())

--- a/src/tests/integration/test_user_management.py
+++ b/src/tests/integration/test_user_management.py
@@ -320,9 +320,9 @@ def test_count_users_by_service_type_rejects_master_key(mocked_client_integratio
 
 
 def test_signup_cap_status_success(mocked_client_integration, mocker):
-    from tests.mocks import MockAppAttestPGService
+    from tests.mocks import MockAppAttestPGService, MockLiteLLMPGService
 
-    mock_app_attest_pg = MockAppAttestPGService()
+    mock_app_attest_pg = MockAppAttestPGService(MockLiteLLMPGService())
     mock_app_attest_pg.managed_capacity_claims.add("fxa-user-a")
     mock_app_attest_pg.managed_capacity_claims.add("fxa-user-b")
     mocker.patch("mlpa.core.routers.user.user.app_attest_pg", mock_app_attest_pg)

--- a/src/tests/integration/test_user_management.py
+++ b/src/tests/integration/test_user_management.py
@@ -1,3 +1,5 @@
+from fastapi import HTTPException
+
 from mlpa.core.config import env
 from tests.consts import TEST_USER_ID
 
@@ -318,12 +320,12 @@ def test_count_users_by_service_type_rejects_master_key(mocked_client_integratio
 
 
 def test_signup_cap_status_success(mocked_client_integration, mocker):
-    from tests.mocks import MockLiteLLMPGService
+    from tests.mocks import MockAppAttestPGService
 
-    mock_litellm_pg = MockLiteLLMPGService()
-    mock_litellm_pg.managed_capacity_claims.add("fxa-user-a")
-    mock_litellm_pg.managed_capacity_claims.add("fxa-user-b")
-    mocker.patch("mlpa.core.routers.user.user.litellm_pg", mock_litellm_pg)
+    mock_app_attest_pg = MockAppAttestPGService()
+    mock_app_attest_pg.managed_capacity_claims.add("fxa-user-a")
+    mock_app_attest_pg.managed_capacity_claims.add("fxa-user-b")
+    mocker.patch("mlpa.core.routers.user.user.app_attest_pg", mock_app_attest_pg)
 
     response = mocked_client_integration.get(
         "/user/signup-cap-status",

--- a/src/tests/mocks.py
+++ b/src/tests/mocks.py
@@ -71,7 +71,7 @@ async def mock_app_attest_auth(app_attest_jwt: str):
     return {"username": "testuser"}
 
 
-async def mock_get_or_create_user(mock_litellm_pg, user_id: str):
+async def mock_get_or_create_user(mock_litellm_pg, mock_app_attest_pg, user_id: str):
     user = await mock_litellm_pg.get_user(user_id)
     if not user:
         # Match real admission semantics:
@@ -82,7 +82,10 @@ async def mock_get_or_create_user(mock_litellm_pg, user_id: str):
             env.MLPA_ENFORCE_SIGNIN_CAP
             and service_type in env.MLPA_CAPPED_SERVICE_TYPES
         ):
-            admitted, newly_claimed = await mock_litellm_pg.admit_managed_base_identity(
+            (
+                admitted,
+                newly_claimed,
+            ) = await mock_app_attest_pg.admit_managed_base_identity(
                 base_identity=base_identity
             )
             if not admitted:
@@ -109,6 +112,8 @@ class MockAppAttestPGService:
         self.connected = True
         self.challenges = {}
         self.keys = {}
+        self.litellm_pg = None
+        self.managed_capacity_claims: set[str] = set()
 
     async def connect(self):
         pass
@@ -146,6 +151,58 @@ class MockAppAttestPGService:
 
     async def delete_key(self, key_id_b64: str):
         del self.keys[key_id_b64]
+
+    async def ensure_capacity_state(self):
+        """Mock ensure_capacity_state method for testing."""
+        logger.debug("mock ensure_capacity_state called")
+        # No-op: the in-memory store_user/admission logic simulates capacity.
+
+    async def admit_managed_base_identity(
+        self, base_identity: str
+    ) -> tuple[bool, bool]:
+        """Mock DB-backed admission: reserve a managed base identity slot."""
+        if not env.MLPA_ENFORCE_SIGNIN_CAP:
+            return True, False
+        if base_identity in self.managed_capacity_claims:
+            return True, False
+        if len(self.managed_capacity_claims) >= env.MLPA_MAX_SIGNED_IN_USERS:
+            return False, False
+        self.managed_capacity_claims.add(base_identity)
+        return True, True
+
+    async def maybe_release_managed_base_identity_if_no_managed_users(
+        self, base_identity: str
+    ) -> None:
+        """Release a managed capacity claim if no managed service rows exist for the base identity."""
+        if not env.MLPA_ENFORCE_SIGNIN_CAP:
+            return
+        if base_identity not in self.managed_capacity_claims:
+            return
+
+        managed_service_types = env.MLPA_CAPPED_SERVICE_TYPES
+        if self.litellm_pg is None:
+            return
+        has_managed_user_rows = any(
+            (p := uid.partition(":"))[0] == base_identity
+            and p[2] in managed_service_types
+            for uid in self.litellm_pg.users
+            if ":" in uid
+        )
+        if not has_managed_user_rows:
+            self.managed_capacity_claims.remove(base_identity)
+
+    async def get_signup_cap_status(self) -> dict:
+        current = len(self.managed_capacity_claims)
+        max_i = env.MLPA_MAX_SIGNED_IN_USERS
+        return {
+            "enforce_signin_cap": env.MLPA_ENFORCE_SIGNIN_CAP,
+            "capped_service_types": sorted(env.MLPA_CAPPED_SERVICE_TYPES),
+            "max_signed_in_users": max_i,
+            "current_managed_identities": current,
+            "slots_remaining": max(0, max_i - current),
+            "capacity_updated_at": None,
+            "capacity_row_missing": False,
+        }
 
 
 class MockLiteLLMPGService:
@@ -188,11 +245,6 @@ class MockLiteLLMPGService:
         logger.debug("mock create_budget called")
         return []
 
-    async def ensure_capacity_state(self):
-        """Mock ensure_capacity_state method for testing."""
-        logger.debug("mock ensure_capacity_state called")
-        # No-op: the in-memory store_user/admission logic simulates capacity.
-
     async def block_user(self, user_id: str, blocked: bool = True):
         """Mock block_user method for testing."""
         logger.debug(
@@ -232,38 +284,6 @@ class MockLiteLLMPGService:
             "offset": offset,
         }
 
-    async def admit_managed_base_identity(
-        self, base_identity: str
-    ) -> tuple[bool, bool]:
-        """Mock DB-backed admission: reserve a managed base identity slot."""
-        if not env.MLPA_ENFORCE_SIGNIN_CAP:
-            return True, False
-        if base_identity in self.managed_capacity_claims:
-            return True, False
-        if len(self.managed_capacity_claims) >= env.MLPA_MAX_SIGNED_IN_USERS:
-            return False, False
-        self.managed_capacity_claims.add(base_identity)
-        return True, True
-
-    async def maybe_release_managed_base_identity_if_no_managed_users(
-        self, base_identity: str
-    ) -> None:
-        """Release a managed capacity claim if no managed service rows exist for the base identity."""
-        if not env.MLPA_ENFORCE_SIGNIN_CAP:
-            return
-        if base_identity not in self.managed_capacity_claims:
-            return
-
-        managed_service_types = env.MLPA_CAPPED_SERVICE_TYPES
-        has_managed_user_rows = any(
-            (p := uid.partition(":"))[0] == base_identity
-            and p[2] in managed_service_types
-            for uid in self.users
-            if ":" in uid
-        )
-        if not has_managed_user_rows:
-            self.managed_capacity_claims.remove(base_identity)
-
     async def count_users_by_service_type(self) -> dict:
         """Mock count_users_by_service_type grouped by service_type."""
         service_type_counts: dict[str, int] = {}
@@ -279,19 +299,6 @@ class MockLiteLLMPGService:
         return {
             "service_type_counts": service_type_counts,
             "total_users": total_users,
-        }
-
-    async def get_signup_cap_status(self) -> dict:
-        current = len(self.managed_capacity_claims)
-        max_i = env.MLPA_MAX_SIGNED_IN_USERS
-        return {
-            "enforce_signin_cap": env.MLPA_ENFORCE_SIGNIN_CAP,
-            "capped_service_types": sorted(env.MLPA_CAPPED_SERVICE_TYPES),
-            "max_signed_in_users": max_i,
-            "current_managed_identities": current,
-            "slots_remaining": max(0, max_i - current),
-            "capacity_updated_at": None,
-            "capacity_row_missing": False,
         }
 
 

--- a/src/tests/mocks.py
+++ b/src/tests/mocks.py
@@ -105,14 +105,14 @@ async def mock_get_completion(authorized_chat_request: AuthorizedChatRequest):
 
 
 class MockAppAttestPGService:
-    def __init__(self):
+    def __init__(self, litellm_pg):
         self.pg = "MOCK NOT IMPLEMENTED"
         self.db_name = "test"
         self.db_url = "test_app_attest"
         self.connected = True
         self.challenges = {}
         self.keys = {}
-        self.litellm_pg = None
+        self.litellm_pg = litellm_pg
         self.managed_capacity_claims: set[str] = set()
 
     async def connect(self):


### PR DESCRIPTION
## What's new

- Move user capacity table to alembic migration
- Move user capacity tables to `appattest` DB (will rename DB to something more "all-purpose" down the line)
- Update `litellm_pg` and `app_attest_pg` usage accordingly
- Update mocks and tests

[corresponding dataservices-infra MR](https://github.com/mozilla/dataservices-infra/pull/1772)

[AIPLAT-68](https://mozilla-hub.atlassian.net/browse/AIPLAT-68)