### PR TITLE
feat: implement stream disconnect method AIPLAT-617

### DIFF
--- a/src/mlpa/core/completions.py
+++ b/src/mlpa/core/completions.py
@@ -1,3 +1,5 @@
+import asyncio
+import contextlib
 import json
 import time
 
@@ -229,6 +231,20 @@ async def stream_completion(
     logger.debug(
         f"Starting a stream completion using {authorized_chat_request.model}, for user {authorized_chat_request.user}",
     )
+
+    disconnect_event = asyncio.Event()
+    _client_disconnected_msg = (
+        f"Client disconnected mid-stream for user {authorized_chat_request.user}"
+    )
+
+    async def _watch_disconnect() -> None:
+        while True:
+            message = await request._receive()
+            if message.get("type") == "http.disconnect":
+                disconnect_event.set()
+                return
+
+    watch_task = asyncio.create_task(_watch_disconnect())
     try:
         client = get_http_client()
         async with client.stream(
@@ -281,11 +297,9 @@ async def stream_completion(
             litellm_routing_snapshot = parse_litellm_routing_headers(response.headers)
 
             async for chunk in response.aiter_bytes():
-                if await request.is_disconnected():
+                if disconnect_event.is_set():
                     result = PrometheusResult.ABORTED
-                    logger.info(
-                        f"Client disconnected mid-stream for user {authorized_chat_request.user}"
-                    )
+                    logger.info(_client_disconnected_msg)
                     break
 
                 if is_first_token:
@@ -386,6 +400,12 @@ async def stream_completion(
         else:
             logger.error(f"Upstream service returned an error: {e}")
     finally:
+        watch_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await watch_task
+        if result == PrometheusResult.ERROR and disconnect_event.is_set():
+            result = PrometheusResult.ABORTED
+            logger.info(_client_disconnected_msg)
         metrics.chat_completion_latency.labels(
             result=result,
             model=authorized_chat_request.model,

--- a/src/mlpa/core/completions.py
+++ b/src/mlpa/core/completions.py
@@ -2,7 +2,7 @@ import json
 import time
 
 import httpx
-from fastapi import HTTPException
+from fastapi import HTTPException, Request
 
 from mlpa.core.classes import AuthorizedChatRequest, LitellmRoutingSnapshot
 from mlpa.core.config import (
@@ -202,7 +202,9 @@ def _record_tool_metrics(
         ).observe(n_calls)
 
 
-async def stream_completion(authorized_chat_request: AuthorizedChatRequest):
+async def stream_completion(
+    authorized_chat_request: AuthorizedChatRequest, request: Request
+):
     """
     Proxies a streaming request to LiteLLM.
     Yields response chunks as they are received and logs metrics.
@@ -279,6 +281,13 @@ async def stream_completion(authorized_chat_request: AuthorizedChatRequest):
             litellm_routing_snapshot = parse_litellm_routing_headers(response.headers)
 
             async for chunk in response.aiter_bytes():
+                if await request.is_disconnected():
+                    result = PrometheusResult.ABORTED
+                    logger.info(
+                        f"Client disconnected mid-stream for user {authorized_chat_request.user}"
+                    )
+                    break
+
                 if is_first_token:
                     metrics.chat_completion_ttft.labels(
                         model=authorized_chat_request.model
@@ -348,23 +357,24 @@ async def stream_completion(authorized_chat_request: AuthorizedChatRequest):
                     service_type=authorized_chat_request.service_type,
                     purpose=authorized_chat_request.purpose,
                 ).observe(completion_tokens)
-            tool_names = [
-                tool_calls_accum[i]["function"].get("name") or "unknown"
-                for i in sorted(tool_calls_accum)
-            ]
-            _record_tool_metrics(
-                authorized_chat_request.model,
-                authorized_chat_request.service_type,
-                authorized_chat_request.purpose,
-                tool_names,
-            )
-            _record_litellm_routing_metrics(
-                authorized_chat_request,
-                litellm_routing_snapshot,
-                prompt_tokens,
-                completion_tokens,
-            )
-            result = PrometheusResult.SUCCESS
+            if result != PrometheusResult.ABORTED:
+                tool_names = [
+                    tool_calls_accum[i]["function"].get("name") or "unknown"
+                    for i in sorted(tool_calls_accum)
+                ]
+                _record_tool_metrics(
+                    authorized_chat_request.model,
+                    authorized_chat_request.service_type,
+                    authorized_chat_request.purpose,
+                    tool_names,
+                )
+                _record_litellm_routing_metrics(
+                    authorized_chat_request,
+                    litellm_routing_snapshot,
+                    prompt_tokens,
+                    completion_tokens,
+                )
+                result = PrometheusResult.SUCCESS
     except httpx.HTTPStatusError as e:
         if not streaming_started:
             yield raise_and_log(e, True)

--- a/src/mlpa/core/completions.py
+++ b/src/mlpa/core/completions.py
@@ -298,7 +298,7 @@ async def stream_completion(
 
             async for chunk in response.aiter_bytes():
                 if disconnect_event.is_set():
-                    result = PrometheusResult.ABORTED
+                    result = PrometheusResult.ABORT
                     logger.info(_client_disconnected_msg)
                     break
 
@@ -371,7 +371,7 @@ async def stream_completion(
                     service_type=authorized_chat_request.service_type,
                     purpose=authorized_chat_request.purpose,
                 ).observe(completion_tokens)
-            if result != PrometheusResult.ABORTED:
+            if result != PrometheusResult.ABORT:
                 tool_names = [
                     tool_calls_accum[i]["function"].get("name") or "unknown"
                     for i in sorted(tool_calls_accum)
@@ -400,11 +400,13 @@ async def stream_completion(
         else:
             logger.error(f"Upstream service returned an error: {e}")
     finally:
+        # Cancel the disconnect watcher and wait for it to finish to avoid
+        # "Task was destroyed but it is pending" warnings at shutdown.
         watch_task.cancel()
         with contextlib.suppress(asyncio.CancelledError):
             await watch_task
         if result == PrometheusResult.ERROR and disconnect_event.is_set():
-            result = PrometheusResult.ABORTED
+            result = PrometheusResult.ABORT
             logger.info(_client_disconnected_msg)
         metrics.chat_completion_latency.labels(
             result=result,

--- a/src/mlpa/core/prometheus_metrics.py
+++ b/src/mlpa/core/prometheus_metrics.py
@@ -7,7 +7,7 @@ from prometheus_client import Counter, Gauge, Histogram
 class PrometheusResult(StrEnum):
     SUCCESS = "success"
     ERROR = "error"
-    ABORTED = "aborted"
+    ABORT = "abort"
 
 
 class PrometheusRejectionReason(StrEnum):

--- a/src/mlpa/core/prometheus_metrics.py
+++ b/src/mlpa/core/prometheus_metrics.py
@@ -7,6 +7,7 @@ from prometheus_client import Counter, Gauge, Histogram
 class PrometheusResult(StrEnum):
     SUCCESS = "success"
     ERROR = "error"
+    ABORTED = "aborted"
 
 
 class PrometheusRejectionReason(StrEnum):

--- a/src/mlpa/run.py
+++ b/src/mlpa/run.py
@@ -160,6 +160,7 @@ Authorize first using App Attest, Play Integrity, FxA, or dev tier.
     responses=cast(dict[int | str, dict[str, Any]], RATE_LIMIT_ERROR_RESPONSE),
 )
 async def chat_completion(
+    request: Request,
     authorized_chat_request: Annotated[
         AuthorizedChatRequest, Depends(authorize_request)
     ],
@@ -176,7 +177,7 @@ async def chat_completion(
 
     if authorized_chat_request.stream:
         return StreamingResponse(
-            stream_completion(authorized_chat_request),
+            stream_completion(authorized_chat_request, request),
             media_type="text/event-stream",
         )
     else:

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -1,6 +1,15 @@
+from unittest.mock import AsyncMock, MagicMock
+
 import pytest
 
 from mlpa.core.config import env
+
+
+@pytest.fixture
+def mock_request():
+    req = MagicMock()
+    req.is_disconnected = AsyncMock(return_value=False)
+    return req
 
 
 @pytest.fixture(autouse=True, scope="session")

--- a/src/tests/unit/test_completions.py
+++ b/src/tests/unit/test_completions.py
@@ -306,7 +306,7 @@ async def test_get_completion_network_error(mocker):
     mock_metrics.chat_completion_latency.labels().observe.assert_called_once()
 
 
-async def test_stream_completion_success(httpx_mock: HTTPXMock, mocker):
+async def test_stream_completion_success(httpx_mock: HTTPXMock, mocker, mock_request):
     """
     Tests the successful execution of a streaming request using pytest-httpx.
     - Verifies the yielded chunks are correct.
@@ -325,7 +325,9 @@ async def test_stream_completion_success(httpx_mock: HTTPXMock, mocker):
 
     mock_metrics = mocker.patch("mlpa.core.completions.metrics")
 
-    received_chunks = [chunk async for chunk in stream_completion(SAMPLE_REQUEST)]
+    received_chunks = [
+        chunk async for chunk in stream_completion(SAMPLE_REQUEST, mock_request)
+    ]
 
     assert received_chunks == mock_chunks
 
@@ -407,7 +409,7 @@ async def test_stream_completion_success(httpx_mock: HTTPXMock, mocker):
 
 
 async def test_stream_completion_litellm_routing_with_fallback(
-    httpx_mock: HTTPXMock, mocker
+    httpx_mock: HTTPXMock, mocker, mock_request
 ):
     usage_chunk = b'data: {"usage": {"prompt_tokens": 10, "completion_tokens": 25}}'
     mock_chunks = [b"data: chunk1", usage_chunk, b"data: [DONE]"]
@@ -423,7 +425,9 @@ async def test_stream_completion_litellm_routing_with_fallback(
     )
 
     mock_metrics = mocker.patch("mlpa.core.completions.metrics")
-    received_chunks = [chunk async for chunk in stream_completion(SAMPLE_REQUEST)]
+    received_chunks = [
+        chunk async for chunk in stream_completion(SAMPLE_REQUEST, mock_request)
+    ]
     assert received_chunks == mock_chunks
 
     routing = _litellm_routing_label_base()
@@ -764,7 +768,7 @@ async def test_get_completion_429_invalid_json(mocker):
 
 
 async def test_stream_completion_budget_limit_exceeded_429(
-    httpx_mock: HTTPXMock, mocker
+    httpx_mock: HTTPXMock, mocker, mock_request
 ):
     """
     Tests that a 429 error with budget exceeded message yields error code 1.
@@ -788,7 +792,9 @@ async def test_stream_completion_budget_limit_exceeded_429(
     mock_metrics = mocker.patch("mlpa.core.completions.metrics")
     mock_logger = mocker.patch("mlpa.core.completions.logger")
 
-    received_chunks = [chunk async for chunk in stream_completion(SAMPLE_REQUEST)]
+    received_chunks = [
+        chunk async for chunk in stream_completion(SAMPLE_REQUEST, mock_request)
+    ]
     assert len(received_chunks) == 1
     assert (
         received_chunks[0]
@@ -812,7 +818,7 @@ async def test_stream_completion_budget_limit_exceeded_429(
 
 
 async def test_stream_completion_budget_limit_exceeded_400(
-    httpx_mock: HTTPXMock, mocker
+    httpx_mock: HTTPXMock, mocker, mock_request
 ):
     """
     Tests that a 400 error with budget exceeded message yields error code 1.
@@ -836,7 +842,9 @@ async def test_stream_completion_budget_limit_exceeded_400(
     mock_metrics = mocker.patch("mlpa.core.completions.metrics")
     mock_logger = mocker.patch("mlpa.core.completions.logger")
 
-    received_chunks = [chunk async for chunk in stream_completion(SAMPLE_REQUEST)]
+    received_chunks = [
+        chunk async for chunk in stream_completion(SAMPLE_REQUEST, mock_request)
+    ]
 
     assert len(received_chunks) == 1
     assert (
@@ -860,7 +868,9 @@ async def test_stream_completion_budget_limit_exceeded_400(
     )
 
 
-async def test_stream_completion_rate_limit_exceeded(httpx_mock: HTTPXMock, mocker):
+async def test_stream_completion_rate_limit_exceeded(
+    httpx_mock: HTTPXMock, mocker, mock_request
+):
     """
     Tests that a rate limit error (TPM/RPM) yields error code 2.
     """
@@ -883,7 +893,9 @@ async def test_stream_completion_rate_limit_exceeded(httpx_mock: HTTPXMock, mock
     mock_metrics = mocker.patch("mlpa.core.completions.metrics")
     mock_logger = mocker.patch("mlpa.core.completions.logger")
 
-    received_chunks = [chunk async for chunk in stream_completion(SAMPLE_REQUEST)]
+    received_chunks = [
+        chunk async for chunk in stream_completion(SAMPLE_REQUEST, mock_request)
+    ]
 
     assert len(received_chunks) == 1
     assert (
@@ -907,7 +919,9 @@ async def test_stream_completion_rate_limit_exceeded(httpx_mock: HTTPXMock, mock
     )
 
 
-async def test_stream_completion_context_window_exceeded(httpx_mock: HTTPXMock, mocker):
+async def test_stream_completion_context_window_exceeded(
+    httpx_mock: HTTPXMock, mocker, mock_request
+):
     """
     Tests that a 400 error with context window exceeded yields 413 SSE payload.
     """
@@ -925,7 +939,9 @@ async def test_stream_completion_context_window_exceeded(httpx_mock: HTTPXMock, 
     mock_metrics = mocker.patch("mlpa.core.completions.metrics")
     mock_logger = mocker.patch("mlpa.core.completions.logger")
 
-    received_chunks = [chunk async for chunk in stream_completion(SAMPLE_REQUEST)]
+    received_chunks = [
+        chunk async for chunk in stream_completion(SAMPLE_REQUEST, mock_request)
+    ]
 
     assert len(received_chunks) == 1
     assert (
@@ -950,7 +966,7 @@ async def test_stream_completion_context_window_exceeded(httpx_mock: HTTPXMock, 
 
 
 async def test_stream_completion_400_non_rate_limit_error(
-    httpx_mock: HTTPXMock, mocker
+    httpx_mock: HTTPXMock, mocker, mock_request
 ):
     """
     Tests that a 400 error without rate limit keywords yields generic error message.
@@ -975,7 +991,9 @@ async def test_stream_completion_400_non_rate_limit_error(
     mock_logger = mocker.patch("mlpa.core.utils.logger")
     mocker.patch.object(env, "MLPA_DEBUG", False)
 
-    received_chunks = [chunk async for chunk in stream_completion(SAMPLE_REQUEST)]
+    received_chunks = [
+        chunk async for chunk in stream_completion(SAMPLE_REQUEST, mock_request)
+    ]
 
     assert len(received_chunks) == 1
     assert (
@@ -992,7 +1010,7 @@ async def test_stream_completion_400_non_rate_limit_error(
 
 
 async def test_stream_completion_429_non_rate_limit_error(
-    httpx_mock: HTTPXMock, mocker
+    httpx_mock: HTTPXMock, mocker, mock_request
 ):
     """
     Tests that a 429 error without rate limit keywords yields generic error message.
@@ -1011,7 +1029,9 @@ async def test_stream_completion_429_non_rate_limit_error(
     mock_logger = mocker.patch("mlpa.core.utils.logger")
     mocker.patch.object(env, "MLPA_DEBUG", False)
 
-    received_chunks = [chunk async for chunk in stream_completion(SAMPLE_REQUEST)]
+    received_chunks = [
+        chunk async for chunk in stream_completion(SAMPLE_REQUEST, mock_request)
+    ]
 
     assert len(received_chunks) == 1
     assert (
@@ -1028,7 +1048,7 @@ async def test_stream_completion_429_non_rate_limit_error(
 
 
 async def test_stream_completion_upstream_rate_limit_error(
-    httpx_mock: HTTPXMock, mocker
+    httpx_mock: HTTPXMock, mocker, mock_request
 ):
     """
     Tests that a 429 upstream throttling error returns error code 5.
@@ -1045,7 +1065,9 @@ async def test_stream_completion_upstream_rate_limit_error(
 
     mock_metrics = mocker.patch("mlpa.core.completions.metrics")
 
-    received_chunks = [chunk async for chunk in stream_completion(SAMPLE_REQUEST)]
+    received_chunks = [
+        chunk async for chunk in stream_completion(SAMPLE_REQUEST, mock_request)
+    ]
 
     assert received_chunks == [
         f'data: {{"error": {ERROR_CODE_UPSTREAM_RATE_LIMIT_EXCEEDED}}}\n\n'.encode()
@@ -1058,7 +1080,9 @@ async def test_stream_completion_upstream_rate_limit_error(
     )
 
 
-async def test_stream_completion_429_invalid_json(httpx_mock: HTTPXMock, mocker):
+async def test_stream_completion_429_invalid_json(
+    httpx_mock: HTTPXMock, mocker, mock_request
+):
     """
     Tests that a 429 error with invalid JSON yields generic error message.
     """
@@ -1073,7 +1097,9 @@ async def test_stream_completion_429_invalid_json(httpx_mock: HTTPXMock, mocker)
     mock_logger = mocker.patch("mlpa.core.utils.logger")
     mocker.patch.object(env, "MLPA_DEBUG", False)
 
-    received_chunks = [chunk async for chunk in stream_completion(SAMPLE_REQUEST)]
+    received_chunks = [
+        chunk async for chunk in stream_completion(SAMPLE_REQUEST, mock_request)
+    ]
 
     assert len(received_chunks) == 1
     assert (
@@ -1090,7 +1116,7 @@ async def test_stream_completion_429_invalid_json(httpx_mock: HTTPXMock, mocker)
 
 
 async def test_stream_completion_exception_after_streaming_started(
-    httpx_mock: HTTPXMock, mocker
+    httpx_mock: HTTPXMock, mocker, mock_request
 ):
     """
     Tests that HTTPStatusError during streaming is logged and returns error chunk.
@@ -1105,7 +1131,7 @@ async def test_stream_completion_exception_after_streaming_started(
     mock_metrics = mocker.patch("mlpa.core.completions.metrics")
 
     received_chunks = []
-    async for chunk in stream_completion(SAMPLE_REQUEST):
+    async for chunk in stream_completion(SAMPLE_REQUEST, mock_request):
         received_chunks.append(chunk)
 
     assert len(received_chunks) == 1
@@ -1182,7 +1208,9 @@ async def test_get_completion_preserves_tools(mocker):
     assert sent_json["messages"] == request_with_tools.messages
 
 
-async def test_stream_completion_preserves_tools(httpx_mock: HTTPXMock, mocker):
+async def test_stream_completion_preserves_tools(
+    httpx_mock: HTTPXMock, mocker, mock_request
+):
     """
     Tests that tool-related fields (tools and tool_choice) are preserved
     when forwarding streaming requests to LiteLLM.
@@ -1238,7 +1266,9 @@ async def test_stream_completion_preserves_tools(httpx_mock: HTTPXMock, mocker):
 
     mock_metrics = mocker.patch("mlpa.core.completions.metrics")
 
-    received_chunks = [chunk async for chunk in stream_completion(request_with_tools)]
+    received_chunks = [
+        chunk async for chunk in stream_completion(request_with_tools, mock_request)
+    ]
 
     request = httpx_mock.get_request()
     assert request is not None

--- a/src/tests/unit/test_timeout_config.py
+++ b/src/tests/unit/test_timeout_config.py
@@ -62,7 +62,9 @@ def test_httpx_client_uses_configurable_timeouts_and_limits(mocker):
     http_client._client = None
 
 
-async def test_stream_completion_uses_configurable_timeout(httpx_mock, mocker):
+async def test_stream_completion_uses_configurable_timeout(
+    httpx_mock, mocker, mock_request
+):
     """Test that stream_completion uses the configurable timeout from env."""
     from pytest_httpx import IteratorStream
 
@@ -80,7 +82,7 @@ async def test_stream_completion_uses_configurable_timeout(httpx_mock, mocker):
     mock_env = mocker.patch("mlpa.core.completions.env")
     mock_env.STREAMING_TIMEOUT_SECONDS = custom_timeout
 
-    async for _ in stream_completion(SAMPLE_REQUEST):
+    async for _ in stream_completion(SAMPLE_REQUEST, mock_request):
         pass
 
     requests = httpx_mock.get_requests()
@@ -88,7 +90,7 @@ async def test_stream_completion_uses_configurable_timeout(httpx_mock, mocker):
     assert mock_env.STREAMING_TIMEOUT_SECONDS == custom_timeout
 
 
-async def test_stream_completion_uses_default_timeout(httpx_mock, mocker):
+async def test_stream_completion_uses_default_timeout(httpx_mock, mocker, mock_request):
     """Test that stream_completion uses default timeout when not configured."""
     from pytest_httpx import IteratorStream
 
@@ -102,7 +104,7 @@ async def test_stream_completion_uses_default_timeout(httpx_mock, mocker):
 
     mocker.patch("mlpa.core.completions.metrics")
 
-    async for _ in stream_completion(SAMPLE_REQUEST):
+    async for _ in stream_completion(SAMPLE_REQUEST, mock_request):
         pass
 
     from mlpa.core.completions import env


### PR DESCRIPTION
Jira: [AIPLAT-617](https://mozilla-hub.atlassian.net/browse/AIPLAT-617)

## What's new:

1. Prometheus.ABORTED value to record partial tokens - this will need Grafana updates
2. catches aborted streaming requests

## QA

1. Tests old and new ✅ 
2. Local QA ✅ 

<img width="2564" height="148" alt="image" src="https://github.com/user-attachments/assets/4dd2eda5-1907-49f5-986e-58979453acfa" />

aborted metrics are recorded

<img width="1442" height="1404" alt="image" src="https://github.com/user-attachments/assets/db205ad4-4bc7-4d29-95a6-2252d7152c90" />
