### PR TITLE
fix: search endpoint

### DIFF
--- a/src/mlpa/run.py
+++ b/src/mlpa/run.py
@@ -186,7 +186,7 @@ async def chat_completion(
 
 
 @app.post(
-    "/v1/search/",
+    "/v1/search",
     tags=["LiteLLM"],
     responses=cast(dict[int | str, dict[str, Any]], RATE_LIMIT_ERROR_RESPONSE),
 )


### PR DESCRIPTION
Remove trailing slash on `/v1/search/`