### PR TITLE
feat: add exa search params, and force service type for certain models (exa: search)

### DIFF
--- a/litellm_config.yaml
+++ b/litellm_config.yaml
@@ -14,6 +14,11 @@ model_list:
     litellm_params:
       model: openai/gpt-4o
       api_key: os.environ/OPENAI_API_KEY
+  - model_name: exa
+    litellm_params:
+      model: openai/exa
+      api_base: https://api.exa.ai
+      api_key: os.environ/EXA_API_KEY
 
 search_tools:
   - search_tool_name: exa-search

--- a/src/mlpa/core/auth/authorize.py
+++ b/src/mlpa/core/auth/authorize.py
@@ -118,6 +118,16 @@ async def authorize_chat_request(
     use_qa_certificates: Annotated[bool | None, Header()] = None,
     use_play_integrity: Annotated[bool | None, Header()] = None,
 ) -> AuthorizedChatRequest:
+    is_service_type_valid = env.valid_service_type_for_model(
+        service_type.value, chat_request.model
+    )
+
+    if not is_service_type_valid:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Invalid service-type value for model {chat_request.model}. Should be one of {env.forced_model_service_type_pairs.get(chat_request.model)}",
+        )
+
     return await _authorize_common_request(
         request=request,
         build_authorized_request=lambda user, purpose_value: AuthorizedChatRequest(
@@ -140,7 +150,7 @@ async def authorize_search_request(
     request: Request,
     search_request: SearchRequest,
     authorization: Annotated[str, Header()],
-    service_type: Annotated[ServiceType, Header()] = ServiceType.ai,
+    service_type: Annotated[ServiceType, Header()] = ServiceType.search,
     purpose: Annotated[str | None, Header()] = None,
     x_dev_authorization: Annotated[str | None, Header()] = None,
     use_app_attest: Annotated[bool | None, Header()] = None,

--- a/src/mlpa/core/classes.py
+++ b/src/mlpa/core/classes.py
@@ -10,9 +10,9 @@ from mlpa.core.config import env
 class ChatRequest(BaseModel):
     # NOTE: this are sanitized parames we are willing to expose to the user
     # full list is https://docs.litellm.ai/docs/completion/input#input-params-1
+    model: str
     stream: Optional[bool] = False
     messages: list[dict] = []
-    model: Optional[str] = env.MODEL_NAME
     temperature: Optional[float] = env.TEMPERATURE
     max_completion_tokens: Optional[int] = env.MAX_COMPLETION_TOKENS
     top_p: Optional[float] = env.TOP_P
@@ -33,6 +33,8 @@ class ChatRequest(BaseModel):
     parallel_tool_calls: Optional[bool] = None
     logprobs: Optional[bool] = None
     top_logprobs: Optional[int] = None
+    # exa search params
+    text: Optional[bool] = None
 
 
 class UserUpdatePayload(BaseModel):

--- a/src/mlpa/core/classes.py
+++ b/src/mlpa/core/classes.py
@@ -10,7 +10,7 @@ from mlpa.core.config import env
 class ChatRequest(BaseModel):
     # NOTE: this are sanitized parames we are willing to expose to the user
     # full list is https://docs.litellm.ai/docs/completion/input#input-params-1
-    model: str
+    model: str = env.MODEL_NAME
     stream: Optional[bool] = False
     messages: list[dict] = []
     temperature: Optional[float] = env.TEMPERATURE

--- a/src/mlpa/core/config.py
+++ b/src/mlpa/core/config.py
@@ -191,6 +191,21 @@ class Env(BaseSettings):
         """True if the purpose header is mandatory for this service type."""
         return len(self.valid_purposes_for_service_type(service_type)) > 0
 
+    @cached_property
+    def forced_model_service_type_pairs(self) -> dict[str, list[str]]:
+        """
+        Returns a dictionary mapping model names to their valid service types.
+        """
+        # Force certain models to use certain service types
+        return {"exa": ["search"]}
+
+    def valid_service_type_for_model(self, service_type: str, model: str) -> bool:
+        """Check if a service type is valid for a specific model."""
+        valid_service_types = self.forced_model_service_type_pairs.get(model)
+        if valid_service_types is None:
+            return True  # Return true if not explicitly configured above
+        return service_type in valid_service_types
+
     # Logging
     LOG_JSON: bool = False  # Set to True for GKE deployment
     LOGURU_LEVEL: str = "INFO"

--- a/src/tests/unit/test_authorize.py
+++ b/src/tests/unit/test_authorize.py
@@ -1,5 +1,5 @@
 import pytest
-from fastapi import Request
+from fastapi import HTTPException, Request
 from pydantic import ValidationError
 
 from mlpa.core.auth import authorize as authorize_module
@@ -56,8 +56,8 @@ async def test_authorize_search_request_returns_authorized_search_request(mocker
     )
 
     assert isinstance(result, AuthorizedSearchRequest)
-    assert result.user == "user-456:ai"
-    assert result.service_type == "ai"
+    assert result.user == "user-456:search"
+    assert result.service_type == "search"
     assert result.purpose == ""
     assert result.query == "latest AI developments"
     assert result.max_results == 2
@@ -69,3 +69,20 @@ def test_search_request_rejects_too_many_results():
 
     errors = exc_info.value.errors()
     assert errors[0]["loc"] == ("max_results",)
+
+
+async def test_authorize_chat_request_rejects_invalid_service_type_for_model():
+    with pytest.raises(HTTPException) as exc_info:
+        await authorize_module.authorize_chat_request(
+            request=_make_request("/v1/chat/completions"),
+            chat_request=ChatRequest(model="exa", messages=[]),
+            authorization="Bearer token",
+            service_type=authorize_module.ServiceType.ai,
+            purpose="chat",
+        )
+
+    assert exc_info.value.status_code == 400
+    assert (
+        exc_info.value.detail
+        == "Invalid service-type value for model exa. Should be one of ['search']"
+    )

--- a/src/tests/unit/test_config.py
+++ b/src/tests/unit/test_config.py
@@ -188,3 +188,26 @@ def test_user_feature_budget_memories_type_validation():
     assert isinstance(memories_config["rpm_limit"], int)
     assert isinstance(memories_config["tpm_limit"], int)
     assert isinstance(memories_config["budget_duration"], str)
+
+
+def test_forced_model_service_type_pairs_defaults():
+    """Test that forced model/service-type mappings include search-only models."""
+    env = Env()
+
+    assert env.forced_model_service_type_pairs == {"exa": ["search"]}
+
+
+def test_valid_service_type_for_model_forced_pair():
+    """Test that forced model/service-type pairs are enforced."""
+    env = Env()
+
+    assert env.valid_service_type_for_model("search", "exa") is True
+    assert env.valid_service_type_for_model("ai", "exa") is False
+
+
+def test_valid_service_type_for_model_unconfigured_model():
+    """Test that unconfigured models accept any service type."""
+    env = Env()
+
+    assert env.valid_service_type_for_model("ai", "gpt-oss-120b") is True
+    assert env.valid_service_type_for_model("search", "gpt-oss-120b") is True


### PR DESCRIPTION
## What's new

- Make `model` required body parameter
- Add `text` as optional body parameter (for exa model)
- Make certain models require certain service types (exa: `search`)

https://mozilla-hub.atlassian.net/browse/AIPLAT-684
[Corresponding dataservices MR](https://github.com/mozilla/dataservices-infra/pull/1883)