### PR TITLE
fix: stream disconnect

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This creates a virtual environment in `.venv/`, installs dependencies, and insta
 
 1. `docker compose -f litellm_docker_compose.yaml up -d`
 
-    (`docker compose down --volumes --remove-orphans` to remove all)
+    (`docker compose -f litellm_docker_compose.yaml down --volumes --remove-orphans` to remove all)
 
 ### Create and migrate appattest database
 

--- a/litellm_docker_compose.yaml
+++ b/litellm_docker_compose.yaml
@@ -35,7 +35,7 @@ services:
     command: redis-server --appendonly yes
 
   litellm:
-    image: ghcr.io/berriai/litellm:v1.82.0-stable
+    image: ghcr.io/berriai/litellm:v1.83.10-stable
     container_name: litellm
     platform: linux/amd64
     depends_on:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mlpa"
-version = "1.0.1"
+version = "1.0.2"
 description = "Authenticates and proxies LLM requests through LiteLLM to enact budgets and per-user management."
 authors = [
     { name = "Noah Podgurski", email = "npodgurski@mozilla.com" },

--- a/src/mlpa/core/completions.py
+++ b/src/mlpa/core/completions.py
@@ -352,7 +352,8 @@ async def stream_completion(
                 except StopAsyncIteration:
                     break
                 except httpx.ReadError:
-                    if disconnect_event.is_set():
+                    if disconnect_event.is_set() or await request.is_disconnected():
+                        disconnect_event.set()
                         result = PrometheusResult.ABORT
                         logger.info(_client_disconnected_msg)
                         break
@@ -460,7 +461,8 @@ async def stream_completion(
                 )
                 result = PrometheusResult.SUCCESS
     except httpx.ReadError as e:
-        if disconnect_event.is_set():
+        if disconnect_event.is_set() or await request.is_disconnected():
+            disconnect_event.set()
             result = PrometheusResult.ABORT
             logger.info(_client_disconnected_msg)
         else:

--- a/src/mlpa/core/completions.py
+++ b/src/mlpa/core/completions.py
@@ -2,6 +2,7 @@ import asyncio
 import contextlib
 import json
 import time
+from collections.abc import AsyncIterator
 
 import httpx
 from fastapi import HTTPException, Request
@@ -49,6 +50,8 @@ _RATE_LIMIT_REJECTION: dict[int, tuple[PrometheusRejectionReason, str]] = {
         "60",
     ),
 }
+
+_DISCONNECT_POLL_INTERVAL_SECONDS = 0.1
 
 
 def _parse_rate_limit_error(error_text: str, user: str) -> int | None:
@@ -249,11 +252,14 @@ async def stream_completion(
     )
 
     async def _watch_disconnect() -> None:
-        while True:
-            message = await request._receive()
-            if message.get("type") == "http.disconnect":
-                disconnect_event.set()
-                return
+        while not await request.is_disconnected():
+            await asyncio.sleep(_DISCONNECT_POLL_INTERVAL_SECONDS)
+        disconnect_event.set()
+
+    async def _read_next_chunk(
+        response_iterator: AsyncIterator[bytes],
+    ) -> bytes:
+        return await response_iterator.__anext__()
 
     watch_task = asyncio.create_task(_watch_disconnect())
     try:
@@ -311,12 +317,48 @@ async def stream_completion(
                 return
 
             litellm_routing_snapshot = parse_litellm_routing_headers(response.headers)
+            response_iterator = response.aiter_bytes()
+            next_chunk_task: asyncio.Task[bytes] | None = None
 
-            async for chunk in response.aiter_bytes():
-                if disconnect_event.is_set():
+            while True:
+                if next_chunk_task is None:
+                    next_chunk_task = asyncio.create_task(
+                        _read_next_chunk(response_iterator)
+                    )
+
+                done, _ = await asyncio.wait(
+                    {next_chunk_task, watch_task},
+                    return_when=asyncio.FIRST_COMPLETED,
+                )
+
+                if watch_task in done:
+                    watch_task.result()
                     result = PrometheusResult.ABORT
                     logger.info(_client_disconnected_msg)
+                    if not next_chunk_task.done():
+                        next_chunk_task.cancel()
+                    with contextlib.suppress(
+                        asyncio.CancelledError,
+                        StopAsyncIteration,
+                        httpx.ReadError,
+                    ):
+                        await next_chunk_task
+                    with contextlib.suppress(httpx.ReadError):
+                        await response.aclose()
                     break
+
+                try:
+                    chunk = next_chunk_task.result()
+                except StopAsyncIteration:
+                    break
+                except httpx.ReadError:
+                    if disconnect_event.is_set():
+                        result = PrometheusResult.ABORT
+                        logger.info(_client_disconnected_msg)
+                        break
+                    raise
+                finally:
+                    next_chunk_task = None
 
                 if is_first_token:
                     metrics.chat_completion_ttft.labels(
@@ -360,6 +402,9 @@ async def stream_completion(
                     pass
 
                 yield chunk
+
+            if result == PrometheusResult.ABORT:
+                return
 
             if not streaming_started:
                 yield raise_and_log(
@@ -414,6 +459,12 @@ async def stream_completion(
                     completion_tokens,
                 )
                 result = PrometheusResult.SUCCESS
+    except httpx.ReadError as e:
+        if disconnect_event.is_set():
+            result = PrometheusResult.ABORT
+            logger.info(_client_disconnected_msg)
+        else:
+            yield raise_and_log(e, True, 502, "Failed to proxy request")
     except Exception as e:
         yield raise_and_log(e, True, 502, "Failed to proxy request")
     finally:

--- a/src/mlpa/core/completions.py
+++ b/src/mlpa/core/completions.py
@@ -51,8 +51,6 @@ _RATE_LIMIT_REJECTION: dict[int, tuple[PrometheusRejectionReason, str]] = {
     ),
 }
 
-_DISCONNECT_POLL_INTERVAL_SECONDS = 0.1
-
 
 def _parse_rate_limit_error(error_text: str, user: str) -> int | None:
     """
@@ -253,7 +251,7 @@ async def stream_completion(
 
     async def _watch_disconnect() -> None:
         while not await request.is_disconnected():
-            await asyncio.sleep(_DISCONNECT_POLL_INTERVAL_SECONDS)
+            await asyncio.sleep(env.DISCONNECT_POLL_INTERVAL_SECONDS)
         disconnect_event.set()
 
     async def _read_next_chunk(

--- a/src/mlpa/core/config.py
+++ b/src/mlpa/core/config.py
@@ -282,6 +282,7 @@ class Env(BaseSettings):
     HTTPX_MAX_CONNECTIONS: int = 200
     HTTPX_MAX_KEEPALIVE_CONNECTIONS: int = 50
     HTTPX_KEEPALIVE_EXPIRY_SECONDS: int = 15
+    DISCONNECT_POLL_INTERVAL_SECONDS: float = 0.1
 
     # Security Headers
     SECURITY_HEADERS_ENABLED: bool = True

--- a/src/tests/unit/test_timeout_config.py
+++ b/src/tests/unit/test_timeout_config.py
@@ -81,6 +81,7 @@ async def test_stream_completion_uses_configurable_timeout(
     custom_timeout = 600
     mock_env = mocker.patch("mlpa.core.completions.env")
     mock_env.STREAMING_TIMEOUT_SECONDS = custom_timeout
+    mock_env.DISCONNECT_POLL_INTERVAL_SECONDS = 0.1
 
     async for _ in stream_completion(SAMPLE_REQUEST, mock_request):
         pass


### PR DESCRIPTION
## What's new

- Fix stream disconnect issue by aborting upstream reads cleanly on client disconnect and avoiding spurious `ReadError` empty-response failures, especially before the first token.