### PR TITLE
feat: search latency metric

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mlpa"
-version = "1.0.0"
+version = "1.0.1"
 description = "Authenticates and proxies LLM requests through LiteLLM to enact budgets and per-user management."
 authors = [
     { name = "Noah Podgurski", email = "npodgurski@mozilla.com" },

--- a/src/mlpa/core/completions.py
+++ b/src/mlpa/core/completions.py
@@ -593,3 +593,9 @@ async def get_search(authorized_search_request: AuthorizedSearchRequest):
         raise
     except Exception as e:
         raise_and_log(e, False, 502, "Failed to proxy request")
+    finally:
+        metrics.search_latency.labels(
+            result=result,
+            service_type=authorized_search_request.service_type,
+            purpose=authorized_search_request.purpose,
+        ).observe(time.perf_counter() - start_time)

--- a/src/mlpa/core/completions.py
+++ b/src/mlpa/core/completions.py
@@ -596,6 +596,4 @@ async def get_search(authorized_search_request: AuthorizedSearchRequest):
     finally:
         metrics.search_latency.labels(
             result=result,
-            service_type=authorized_search_request.service_type,
-            purpose=authorized_search_request.purpose,
         ).observe(time.perf_counter() - start_time)

--- a/src/mlpa/core/prometheus_metrics.py
+++ b/src/mlpa/core/prometheus_metrics.py
@@ -68,10 +68,13 @@ BUCKETS_LITELLM_ATTEMPTS = (0, 1, 2, 3, 5, float("inf"))
 
 @dataclass
 class PrometheusMetrics:
+    # global request metrics
     in_progress_requests: Gauge
     requests_total: Counter
     response_status_codes: Counter
     request_latency: Histogram
+
+    # auth
     validate_challenge_latency: Histogram
     validate_app_attest_latency: Histogram
     validate_app_assert_latency: Histogram
@@ -81,6 +84,8 @@ class PrometheusMetrics:
     fxa_verifications_total: Counter
     play_verifications_total: Counter
     access_token_verifications_total: Counter
+
+    # chat completions
     chat_completion_latency: Histogram
     chat_completion_ttft: Histogram
     chat_tokens: Counter
@@ -90,6 +95,11 @@ class PrometheusMetrics:
     chat_tool_calls_per_completion: Histogram
     chat_requests_with_tools: Counter
     chat_request_rejections: Counter
+
+    # search
+    search_latency: Histogram
+
+    # litellm
     litellm_routed_completions: Counter
     litellm_attempted_fallbacks: Histogram
     litellm_attempted_retries: Histogram
@@ -215,6 +225,12 @@ metrics = PrometheusMetrics(
         "mlpa_chat_request_rejections_total",
         "Number of chat requests rejected due to budget, rate limit, payload size, or managed-user signup cap.",
         ["reason", "model", "service_type", "purpose"],
+    ),
+    search_latency=Histogram(
+        "mlpa_search_latency_seconds",
+        "Search latency in seconds.",
+        ["result", "service_type", "purpose"],
+        buckets=BUCKETS_COMPLETION,
     ),
     litellm_routed_completions=Counter(
         "mlpa_litellm_routed_completions_total",

--- a/src/mlpa/core/prometheus_metrics.py
+++ b/src/mlpa/core/prometheus_metrics.py
@@ -47,6 +47,17 @@ BUCKETS_COMPLETION = (
     180.0,
     float("inf"),
 )
+BUCKETS_SEARCH = (
+    0.1,
+    0.2,
+    0.5,
+    1.0,
+    2.5,
+    5.0,
+    10.0,
+    20.0,
+    float("inf"),
+)
 BUCKETS_TTFT = (0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, float("inf"))
 BUCKETS_TOOL_CALLS = (0, 1, 2, 3, 5, 10, 20, 50, float("inf"))
 BUCKETS_TOKENS = (
@@ -229,8 +240,8 @@ metrics = PrometheusMetrics(
     search_latency=Histogram(
         "mlpa_search_latency_seconds",
         "Search latency in seconds.",
-        ["result", "service_type", "purpose"],
-        buckets=BUCKETS_COMPLETION,
+        ["result"],
+        buckets=BUCKETS_SEARCH,
     ),
     litellm_routed_completions=Counter(
         "mlpa_litellm_routed_completions_total",

--- a/src/mlpa/core/routers/health/health.py
+++ b/src/mlpa/core/routers/health/health.py
@@ -1,9 +1,12 @@
+import importlib.metadata
+
 from fastapi import APIRouter
 
 from mlpa.core.config import LITELLM_MASTER_AUTH_HEADERS, LITELLM_READINESS_URL
 from mlpa.core.http_client import get_http_client
 from mlpa.core.pg_services.services import app_attest_pg, litellm_pg
 
+mlpa_version = importlib.metadata.version("mlpa")
 router = APIRouter()
 
 
@@ -26,6 +29,7 @@ async def readiness_probe():
     litellm_status = data
     return {
         "status": "connected",
+        "mlpa_version": mlpa_version,
         "pg_server_dbs": {
             "postgres": "connected" if pg_status else "offline",
             "app_attest": "connected" if app_attest_pg_status else "offline",


### PR DESCRIPTION
## What's new

- Add search latency metric to `/v1/search` requests
- Bump version to `1.0.1`
- Add mlpa version to `/readiness` response