### PR TITLE
add PR-number tagging for dev image builds

### DIFF
--- a/.github/workflows/docker-publish-dev.yml
+++ b/.github/workflows/docker-publish-dev.yml
@@ -8,16 +8,61 @@ on:
         required: true
         type: string
 
+env:
+  GCP_PROJECT_ID: moz-fx-llm-proxy-prod-b0b8
+  GAR_REPOSITORY: llm-proxy-prod
+  GAR_NAME: mlpa
+  GAR_LOCATION: us
+  GCPV2_WORKLOAD_IDENTITY_POOL_PROJECT_NUMBER: 324168772199
+  GCPV2_GITHUB_WORKLOAD_IDENTITY_PROVIDER: projects/324168772199/locations/global/workloadIdentityPools/github-actions/providers/github-actions
+
 jobs:
   # docs - https://github.com/mozilla/deploy-actions/blob/main/.github/workflows/docs/build-and-push.md
   build-and-push-dev:
-    secrets: inherit
+    runs-on: ubuntu-latest
+    environment: build
     permissions:
       contents: read
       id-token: write
-    uses: mozilla/deploy-actions/.github/workflows/build-and-push.yml@main
-    with:
-      image_name: mlpa
-      gar_name: llm-proxy-prod
-      project_id: moz-fx-llm-proxy-prod-b0b8
-      should_tag_latest: false
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Authenticate to Google Cloud
+        id: gcp-auth
+        uses: google-github-actions/auth@v2
+        with:
+          token_format: "access_token"
+          service_account: artifact-writer@${{ env.GCP_PROJECT_ID }}.iam.gserviceaccount.com
+          workload_identity_provider: ${{ env.GCPV2_GITHUB_WORKLOAD_IDENTITY_PROVIDER }}
+
+      - name: Login to Google Artifact Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.GAR_LOCATION }}-docker.pkg.dev
+          username: oauth2accesstoken
+          password: ${{ steps.gcp-auth.outputs.access_token }}
+
+      - name: Build and Tag Container Image
+        run: |
+          IMAGE_REPO=${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.GCP_PROJECT_ID }}/${{ env.GAR_REPOSITORY }}/${{ env.GAR_NAME }}
+          SHA_TAG=$IMAGE_REPO:${{ github.sha }}
+          PR_TAG=$IMAGE_REPO:pr-${{ inputs.pr_number }}
+
+          docker build -t $SHA_TAG .
+          docker tag $SHA_TAG $PR_TAG
+          docker tag $SHA_TAG $IMAGE_REPO:latest
+          if [[ "${{ github.ref }}" == refs/tags/* ]]; then
+            docker tag $SHA_TAG $IMAGE_REPO:${{ github.ref_name }}
+          fi
+
+      - name: Push Container Image to GAR
+        run: |
+          IMAGE_REPO=${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.GCP_PROJECT_ID }}/${{ env.GAR_REPOSITORY }}/${{ env.GAR_NAME }}
+
+          docker push $IMAGE_REPO:${{ github.sha }}
+          docker push $IMAGE_REPO:pr-${{ inputs.pr_number }}
+          docker push $IMAGE_REPO:latest
+          if [[ "${{ github.ref }}" == refs/tags/* ]]; then
+            docker push $IMAGE_REPO:${{ github.ref_name }}
+          fi


### PR DESCRIPTION
## What's new

- Use manual build and publish flow for `/build-pr` workflow
- Same flow we used before migrating to `mozilla/deploy-actions` (extra tags not supported in this workflow) https://github.com/Firefox-AI/MLPA/commit/bb150b0c25a538fac2fd468fa94871e5e6cf01a5?diff=split
- Added feature request for multiple tags in build-and-push reusable workflow. Merging this in the meantime