### PR TITLE
chore: Include litellm v readiness

### DIFF
--- a/src/mlpa/core/config.py
+++ b/src/mlpa/core/config.py
@@ -324,6 +324,7 @@ class Env(BaseSettings):
 env = Env()
 
 LITELLM_READINESS_URL = f"{env.LITELLM_API_BASE}/health/readiness"
+LITELLM_INFO_URL = f"{env.LITELLM_API_BASE}/public/model_hub/info"
 LITELLM_COMPLETIONS_URL = f"{env.LITELLM_API_BASE}/v1/chat/completions"
 LITELLM_SEARCH_URL = f"{env.LITELLM_API_BASE}/v1/search"
 LITELLM_MASTER_AUTH_HEADERS = {

--- a/src/mlpa/core/routers/health/health.py
+++ b/src/mlpa/core/routers/health/health.py
@@ -11,7 +11,24 @@ from mlpa.core.http_client import get_http_client
 from mlpa.core.pg_services.services import app_attest_pg, litellm_pg
 
 mlpa_version = importlib.metadata.version("mlpa")
+litellm_version = "N/A"
 router = APIRouter()
+
+
+async def get_litellm_version(client):
+    global litellm_version
+
+    if litellm_version != "N/A":
+        return litellm_version
+
+    try:
+        response = await client.get(LITELLM_INFO_URL, timeout=3)
+        litellm_info = response.json()
+    except Exception:
+        return litellm_version
+
+    litellm_version = litellm_info.get("litellm_version", "N/A")
+    return litellm_version
 
 
 @router.get("/liveness", tags=["Health"])
@@ -29,9 +46,8 @@ async def readiness_probe():
         LITELLM_READINESS_URL, headers=LITELLM_MASTER_AUTH_HEADERS, timeout=3
     )
     litellm_status = response.json()
+    current_litellm_version = await get_litellm_version(client)
 
-    response = await client.get(LITELLM_INFO_URL, timeout=3)
-    litellm_info = response.json()
     return {
         "status": "connected",
         "mlpa_version": mlpa_version,
@@ -40,7 +56,7 @@ async def readiness_probe():
             "app_attest": "connected" if app_attest_pg_status else "offline",
         },
         "litellm": {
-            "litellm_version": litellm_info.get("litellm_version", "N/A"),
+            "litellm_version": current_litellm_version,
             **litellm_status,
         },
     }

--- a/src/mlpa/core/routers/health/health.py
+++ b/src/mlpa/core/routers/health/health.py
@@ -24,7 +24,6 @@ async def readiness_probe():
     # todo add check to PG and LiteLLM status here
     pg_status = litellm_pg.check_status()
     app_attest_pg_status = app_attest_pg.check_status()
-    litellm_status = {}
     client = get_http_client()
     response = await client.get(
         LITELLM_READINESS_URL, headers=LITELLM_MASTER_AUTH_HEADERS, timeout=3
@@ -41,7 +40,7 @@ async def readiness_probe():
             "app_attest": "connected" if app_attest_pg_status else "offline",
         },
         "litellm": {
-            "litellm_version": litellm_info["litellm_version"],
+            "litellm_version": litellm_info.get("litellm_version", "N/A"),
             **litellm_status,
         },
     }

--- a/src/mlpa/core/routers/health/health.py
+++ b/src/mlpa/core/routers/health/health.py
@@ -2,7 +2,11 @@ import importlib.metadata
 
 from fastapi import APIRouter
 
-from mlpa.core.config import LITELLM_MASTER_AUTH_HEADERS, LITELLM_READINESS_URL
+from mlpa.core.config import (
+    LITELLM_INFO_URL,
+    LITELLM_MASTER_AUTH_HEADERS,
+    LITELLM_READINESS_URL,
+)
 from mlpa.core.http_client import get_http_client
 from mlpa.core.pg_services.services import app_attest_pg, litellm_pg
 
@@ -25,8 +29,10 @@ async def readiness_probe():
     response = await client.get(
         LITELLM_READINESS_URL, headers=LITELLM_MASTER_AUTH_HEADERS, timeout=3
     )
-    data = response.json()
-    litellm_status = data
+    litellm_status = response.json()
+
+    response = await client.get(LITELLM_INFO_URL, timeout=3)
+    litellm_info = response.json()
     return {
         "status": "connected",
         "mlpa_version": mlpa_version,
@@ -34,5 +40,8 @@ async def readiness_probe():
             "postgres": "connected" if pg_status else "offline",
             "app_attest": "connected" if app_attest_pg_status else "offline",
         },
-        "litellm": litellm_status,
+        "litellm": {
+            "litellm_version": litellm_info["litellm_version"],
+            **litellm_status,
+        },
     }

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -17,6 +17,12 @@ def mock_request():
 def _force_mlpa_debug_false():
     monkeypatch = pytest.MonkeyPatch()
     monkeypatch.setenv("MLPA_DEBUG", "false")
+    monkeypatch.setenv("ADDITIONAL_FXA_SCOPE_1", None)
+    monkeypatch.setenv("ADDITIONAL_FXA_SCOPE_2", None)
+    monkeypatch.setenv("ADDITIONAL_FXA_SCOPE_3", None)
     env.MLPA_DEBUG = False
+    env.ADDITIONAL_FXA_SCOPE_1 = None
+    env.ADDITIONAL_FXA_SCOPE_2 = None
+    env.ADDITIONAL_FXA_SCOPE_3 = None
     yield
     monkeypatch.undo()

--- a/src/tests/integration/test_fxa.py
+++ b/src/tests/integration/test_fxa.py
@@ -30,7 +30,7 @@ def test_ai_missing_purpose_is_allowed_by_default(mocked_client_integration):
             "authorization": f"Bearer {TEST_FXA_TOKEN}",
             "service-type": "ai",
         },
-        json=SAMPLE_REQUEST.dict(),
+        json=SAMPLE_REQUEST.model_dump(),
     )
     assert response.status_code == 200
     assert response.json() == SUCCESSFUL_CHAT_RESPONSE
@@ -45,7 +45,7 @@ def test_ai_invalid_purpose_returns_400(mocked_client_integration):
             "service-type": "ai",
             "purpose": "invalid-purpose",
         },
-        json=SAMPLE_REQUEST.dict(),
+        json=SAMPLE_REQUEST.model_dump(),
     )
     assert response.status_code == 400
     assert "purpose" in str(response.json().get("detail", "")).lower()
@@ -59,7 +59,7 @@ def test_invalid_fxa_auth(mocked_client_integration):
             "service-type": "ai",
             "purpose": "chat",
         },
-        json=SAMPLE_REQUEST.dict(),
+        json=SAMPLE_REQUEST.model_dump(),
     )
     assert response.status_code == 401
 
@@ -72,7 +72,7 @@ def test_successful_request_with_mocked_fxa_auth(mocked_client_integration):
             "service-type": "ai",
             "purpose": "chat",
         },
-        json=SAMPLE_REQUEST.dict(),
+        json=SAMPLE_REQUEST.model_dump(),
     )
     assert response.status_code != 401
     assert response.status_code != 400
@@ -93,7 +93,7 @@ def test_x_dev_authorization_success(mocked_client_integration):
                 "purpose": "chat",
                 "x-dev-authorization": DEV_TOKEN,
             },
-            json=SAMPLE_REQUEST.dict(),
+            json=SAMPLE_REQUEST.model_dump(),
         )
     assert response.status_code == 200
     assert response.json() == SUCCESSFUL_CHAT_RESPONSE
@@ -112,7 +112,7 @@ def test_x_dev_authorization_missing_fxa(mocked_client_integration):
                 "purpose": "chat",
                 "x-dev-authorization": DEV_TOKEN,
             },
-            json=SAMPLE_REQUEST.dict(),
+            json=SAMPLE_REQUEST.model_dump(),
         )
     assert response.status_code == 422
 
@@ -131,7 +131,7 @@ def test_x_dev_authorization_invalid_token(mocked_client_integration):
                 "purpose": "chat",
                 "x-dev-authorization": "wrong-token",
             },
-            json=SAMPLE_REQUEST.dict(),
+            json=SAMPLE_REQUEST.model_dump(),
         )
     assert response.status_code == 401
 
@@ -149,7 +149,7 @@ def test_x_dev_authorization_token_not_configured(mocked_client_integration):
                 "purpose": "chat",
                 "x-dev-authorization": "some-token",
             },
-            json=SAMPLE_REQUEST.dict(),
+            json=SAMPLE_REQUEST.model_dump(),
         )
     assert response.status_code == 422
 
@@ -163,7 +163,7 @@ def test_ai_dev_requires_x_dev_authorization(mocked_client_integration):
             "service-type": "ai-dev",
             "purpose": "chat",
         },
-        json=SAMPLE_REQUEST.dict(),
+        json=SAMPLE_REQUEST.model_dump(),
     )
     assert response.status_code == 401
     assert "x-dev-authorization required" in str(response.json().get("detail", ""))
@@ -186,7 +186,7 @@ def test_x_dev_authorization_ignored_for_non_dev_service_type(
                 "purpose": "chat",
                 "x-dev-authorization": DEV_TOKEN,
             },
-            json=SAMPLE_REQUEST.dict(),
+            json=SAMPLE_REQUEST.model_dump(),
         )
     assert response.status_code == 200
     assert response.json() == SUCCESSFUL_CHAT_RESPONSE
@@ -206,7 +206,7 @@ def test_x_dev_authorization_token_not_configured_with_fxa(mocked_client_integra
                 "purpose": "chat",
                 "x-dev-authorization": "some-token",
             },
-            json=SAMPLE_REQUEST.dict(),
+            json=SAMPLE_REQUEST.model_dump(),
         )
     assert response.status_code == 401
     assert "Invalid x-dev-authorization" in str(response.json().get("detail", ""))

--- a/src/tests/integration/test_health.py
+++ b/src/tests/integration/test_health.py
@@ -1,3 +1,5 @@
+import importlib.metadata
+
 from mlpa.core.config import env
 
 
@@ -8,39 +10,33 @@ def test_health_liveness(mocked_client_integration, httpx_mock):
 
 
 def test_health_readiness(mocked_client_integration, httpx_mock):
+    mlpa_version = importlib.metadata.version("mlpa")
     httpx_mock.add_response(
         method="GET",
         url=f"{env.LITELLM_API_BASE}/health/readiness",
         status_code=200,
         json={
-            "status": "connected",
-            "pg_server_dbs": {"postgres": "connected", "app_attest": "connected"},
-            "litellm": {
-                "status": "connected",
-                "db": "connected",
-                "cache": None,
-                "litellm_version": "1.77.3",
-                "success_callbacks": [
-                    "sync_deployment_callback_on_success",
-                    "_PROXY_VirtualKeyModelMaxBudgetLimiter",
-                    "_ProxyDBLogger",
-                    "_PROXY_MaxBudgetLimiter",
-                    "_PROXY_MaxParallelRequestsHandler_v3",
-                    "_PROXY_CacheControlCheck",
-                    "_PROXY_LiteLLMManagedFiles",
-                    "ServiceLogging",
-                ],
-                "use_aiohttp_transport": True,
-                "last_updated": "2025-10-10T00:00:00",
-            },
+            "status": "healthy",
+            "db": "connected",
         },
+    )
+    httpx_mock.add_response(
+        method="GET",
+        url=f"{env.LITELLM_API_BASE}/public/model_hub/info",
+        status_code=200,
+        json={"litellm_version": "1.84.4"},
     )
 
     readiness_response = mocked_client_integration.get("/health/readiness")
     assert readiness_response.status_code == 200
     assert readiness_response.json().get("status") == "connected"
+    assert readiness_response.json().get("mlpa_version") == mlpa_version
     assert readiness_response.json().get("pg_server_dbs") is not None
-    assert readiness_response.json().get("litellm") is not None
+    assert readiness_response.json().get("litellm") == {
+        "litellm_version": "1.84.4",
+        "status": "healthy",
+        "db": "connected",
+    }
 
 
 def test_metrics_endpoint(mocked_client_integration):

--- a/src/tests/integration/test_security_headers.py
+++ b/src/tests/integration/test_security_headers.py
@@ -50,7 +50,13 @@ def test_security_headers_on_all_endpoints(mocked_client_integration, httpx_mock
         method="GET",
         url=f"{env.LITELLM_API_BASE}/health/readiness",
         status_code=200,
-        json={"status": "connected"},
+        json={"status": "healthy", "db": "connected"},
+    )
+    httpx_mock.add_response(
+        method="GET",
+        url=f"{env.LITELLM_API_BASE}/public/model_hub/info",
+        status_code=200,
+        json={"litellm_version": "1.84.4"},
     )
 
     endpoints = [

--- a/src/tests/integration/test_user_signup_cap.py
+++ b/src/tests/integration/test_user_signup_cap.py
@@ -12,6 +12,11 @@ def use_real_get_or_create_user():
     return True
 
 
+@pytest.fixture(autouse=True)
+def single_fxa_scope(mocker):
+    mocker.patch("mlpa.core.auth.fxa.FXA_SCOPES", ("profile:uid",))
+
+
 class _FakeResponse:
     def __init__(self, payload: dict):
         self._payload = payload

--- a/src/tests/integration/test_user_signup_cap.py
+++ b/src/tests/integration/test_user_signup_cap.py
@@ -101,7 +101,7 @@ def test_managed_cap_rejects_new_identities_and_s2s_bypasses(
                 "authorization": f"Bearer {TEST_FXA_TOKEN}",
                 "service-type": "ai",
             },
-            json=SAMPLE_REQUEST.dict(),
+            json=SAMPLE_REQUEST.model_dump(),
         )
         assert resp1.status_code == 200
         assert resp1.json() == SUCCESSFUL_CHAT_RESPONSE
@@ -112,7 +112,7 @@ def test_managed_cap_rejects_new_identities_and_s2s_bypasses(
                 "authorization": f"Bearer {TEST_FXA_TOKEN}",
                 "service-type": "s2s",
             },
-            json=SAMPLE_REQUEST.dict(),
+            json=SAMPLE_REQUEST.model_dump(),
         )
         assert resp2.status_code == 200
         assert resp2.json() == SUCCESSFUL_CHAT_RESPONSE
@@ -123,7 +123,7 @@ def test_managed_cap_rejects_new_identities_and_s2s_bypasses(
                 "authorization": f"Bearer {TEST_FXA_TOKEN}",
                 "service-type": "ai",
             },
-            json=SAMPLE_REQUEST.dict(),
+            json=SAMPLE_REQUEST.model_dump(),
         )
         assert resp3.status_code == 403
         assert resp3.json()["detail"]["error"] == 4
@@ -139,7 +139,7 @@ def test_managed_cap_rejects_new_identities_and_s2s_bypasses(
                 "authorization": f"Bearer {TEST_FXA_TOKEN}",
                 "service-type": "memories",
             },
-            json=SAMPLE_REQUEST.dict(),
+            json=SAMPLE_REQUEST.model_dump(),
         )
         assert resp4.status_code == 200
         assert resp4.json() == SUCCESSFUL_CHAT_RESPONSE
@@ -189,7 +189,7 @@ def test_release_reserved_slot_when_litellm_user_creation_fails(
                 "authorization": f"Bearer {TEST_FXA_TOKEN}",
                 "service-type": "ai",
             },
-            json=SAMPLE_REQUEST.dict(),
+            json=SAMPLE_REQUEST.model_dump(),
         )
         assert resp1.status_code == 500
 
@@ -199,7 +199,7 @@ def test_release_reserved_slot_when_litellm_user_creation_fails(
                 "authorization": f"Bearer {TEST_FXA_TOKEN}",
                 "service-type": "ai",
             },
-            json=SAMPLE_REQUEST.dict(),
+            json=SAMPLE_REQUEST.model_dump(),
         )
         assert resp2.status_code == 200
         assert resp2.json() == SUCCESSFUL_CHAT_RESPONSE


### PR DESCRIPTION
## What's new

- LiteLLM updated their readiness to not include the version anymore
- Re-include it in MLPA `/health/readiness` by calling `public/model_hub/info`
- Fix warnings, make tests more consistent

Before:
```
{
  "status": "connected",
  "mlpa_version": "1.0.12",
  "pg_server_dbs": {
    "postgres": "connected",
    "app_attest": "connected"
  },
  "litellm": {
    "status": "healthy",
    "db": "connected"
  }
}
```

After:
```
{
  "status": "connected",
  "mlpa_version": "1.0.12",
  "pg_server_dbs": {
    "postgres": "connected",
    "app_attest": "connected"
  },
  "litellm": {
    "litellm_version": "1.84.4",
    "status": "healthy",
    "db": "connected"
  }
}
```

https://mozilla-hub.atlassian.net/browse/AIPLAT-1035