### PR TITLE
fix: stream-contextvar-crashregression

### DIFF
--- a/src/mlpa/core/completions.py
+++ b/src/mlpa/core/completions.py
@@ -85,30 +85,16 @@ async def get_or_create_user_for_completion(
 async def stream_completion(
     authorized_chat_request: AuthorizedChatRequest, request: Request
 ):
-    """Bind request log fields onto the loguru contextvar, then stream.
-
-    The contextvar must be held *inside* the generator (not the route handler)
-    so it stays active while Starlette iterates the SSE body — otherwise
-    mid-stream errors would lose the fields (the streaming blind spot).
-    """
-    with logger.contextualize(**authorized_chat_request.log_fields):
-        gen = _stream_completion(authorized_chat_request, request)
-        try:
-            async for chunk in gen:
-                yield chunk
-        finally:
-            # Forward close/GeneratorExit into the inner generator so its
-            # client-disconnect handling runs while the fields are still bound.
-            await gen.aclose()
-
-
-async def _stream_completion(
-    authorized_chat_request: AuthorizedChatRequest, request: Request
-):
     """
     Proxies a streaming request to LiteLLM.
     Yields response chunks as they are received and logs metrics.
+
+    Bind log fields with ``logger.bind``, not ``logger.contextualize``: Starlette
+    tears this generator down from a different asyncio Task on client disconnect,
+    and a contextvar token reset in that foreign Context raises ValueError.
+    ``bind`` has no token to reset.
     """
+    log = logger.bind(**authorized_chat_request.log_fields)
     start_time = time.perf_counter()
     record_request_with_tools(authorized_chat_request)
     body = _build_litellm_body(authorized_chat_request, stream=True)
@@ -119,7 +105,7 @@ async def _stream_completion(
     completion_tokens = 0
     streaming_started = False
     tool_calls_accum: dict[int, dict] = {}
-    logger.debug(
+    log.debug(
         f"Starting a stream completion using {authorized_chat_request.model}, for user {authorized_chat_request.user}",
     )
 
@@ -171,13 +157,13 @@ async def _stream_completion(
                 )
                 if match is not None:
                     if match.log_message:
-                        logger.warning(match.log_message)
+                        log.warning(match.log_message)
                     record_chat_request_rejection(authorized_chat_request, match.reason)
                     availability_reason = match.availability_reason()
                     yield f'data: {{"error": {match.error_code}}}\n\n'.encode()
                     return
 
-                yield raise_and_log(e, True)
+                yield raise_and_log(e, True, log=log)
                 return
 
             litellm_routing_snapshot = parse_litellm_routing_headers(response.headers)
@@ -197,7 +183,7 @@ async def _stream_completion(
                 if watch_task in done:
                     watch_task.result()
                     result = PrometheusResult.ABORT
-                    logger.info(_client_disconnected_msg)
+                    log.info(_client_disconnected_msg)
                     if not next_chunk_task.done():
                         next_chunk_task.cancel()
                     with contextlib.suppress(
@@ -218,7 +204,7 @@ async def _stream_completion(
                     if disconnect_event.is_set() or await request.is_disconnected():
                         disconnect_event.set()
                         result = PrometheusResult.ABORT
-                        logger.info(_client_disconnected_msg)
+                        log.info(_client_disconnected_msg)
                         break
                     raise
                 finally:
@@ -242,11 +228,11 @@ async def _stream_completion(
                                 prompt_tokens = usage.get("prompt_tokens", 0)
                                 completion_tokens = usage.get("completion_tokens", 0)
                                 if "prompt_tokens" not in usage:
-                                    logger.warning(
+                                    log.warning(
                                         f"Missing 'prompt_tokens' in usage for model {authorized_chat_request.model}"
                                     )
                                 if "completion_tokens" not in usage:
-                                    logger.warning(
+                                    log.warning(
                                         f"Missing 'completion_tokens' in usage for model {authorized_chat_request.model}"
                                     )
                             for tc in (
@@ -278,6 +264,7 @@ async def _stream_completion(
                     True,
                     502,
                     "Empty response from upstream",
+                    log=log,
                 )
                 return
 
@@ -299,17 +286,17 @@ async def _stream_completion(
         # `yield chunk`. This often beats the disconnect poller, so classify it
         # as an abort here rather than letting the initial ERROR stand.
         result = PrometheusResult.ABORT
-        logger.info(_client_disconnected_msg)
+        log.info(_client_disconnected_msg)
         raise
     except httpx.ReadError as e:
         if disconnect_event.is_set() or await request.is_disconnected():
             disconnect_event.set()
             result = PrometheusResult.ABORT
-            logger.info(_client_disconnected_msg)
+            log.info(_client_disconnected_msg)
         else:
-            yield raise_and_log(e, True, 502, "Failed to proxy request")
+            yield raise_and_log(e, True, 502, "Failed to proxy request", log=log)
     except Exception as e:
-        yield raise_and_log(e, True, 502, "Failed to proxy request")
+        yield raise_and_log(e, True, 502, "Failed to proxy request", log=log)
     finally:
         if next_chunk_task is not None:
             if not next_chunk_task.done():
@@ -327,7 +314,7 @@ async def _stream_completion(
             await watch_task
         if result == PrometheusResult.ERROR and disconnect_event.is_set():
             result = PrometheusResult.ABORT
-            logger.info(_client_disconnected_msg)
+            log.info(_client_disconnected_msg)
         if result == PrometheusResult.ABORT:
             availability_reason = AvailabilityReason.CLIENT_DISCONNECT
         record_completion_latency(

--- a/src/mlpa/core/utils.py
+++ b/src/mlpa/core/utils.py
@@ -221,7 +221,7 @@ def raise_and_log(
     response_code: int | None = None,
     response_text_prefix: str | None = None,
     *,
-    log=...,
+    log=logger,
 ) -> bytes: ...
 
 
@@ -232,7 +232,7 @@ def raise_and_log(
     response_code: int | None = None,
     response_text_prefix: str | None = None,
     *,
-    log=...,
+    log=logger,
 ) -> NoReturn: ...
 
 

--- a/src/mlpa/core/utils.py
+++ b/src/mlpa/core/utils.py
@@ -220,6 +220,8 @@ def raise_and_log(
     stream: Literal[True],
     response_code: int | None = None,
     response_text_prefix: str | None = None,
+    *,
+    log=...,
 ) -> bytes: ...
 
 
@@ -229,6 +231,8 @@ def raise_and_log(
     stream: Literal[False] = False,
     response_code: int | None = None,
     response_text_prefix: str | None = None,
+    *,
+    log=...,
 ) -> NoReturn: ...
 
 
@@ -237,6 +241,8 @@ def raise_and_log(
     stream: bool = False,
     response_code: int | None = None,
     response_text_prefix: str | None = None,
+    *,
+    log=logger,
 ) -> bytes | NoReturn:
     """
     Log an upstream exception and return or raise a standardized FastAPI response.
@@ -246,10 +252,9 @@ def raise_and_log(
     If the upstream error body contains a nested error message, it is extracted
     so clients receive the actual upstream detail in debug mode. (dev environment only)
 
-    Request-identifying fields (user / service_type / model / purpose) are not
-    passed here; they are bound on the loguru contextvar by the proxy handler
-    (``logger.contextualize(**req.log_fields)``) so they ride along in
-    ``record.extra`` automatically.
+    Pass ``log`` to log via a pre-bound child logger (the streaming proxy does
+    this); it defaults to the module logger, which carries contextvar-bound
+    request fields for the non-streaming proxy.
     """
     response = getattr(e, "response", None)
     error_text = response.text if response is not None else ""
@@ -276,7 +281,7 @@ def raise_and_log(
     # (logger.opt(exception=...)) so jsonPayload.record.exception is populated.
     exc_type = type(e).__name__
     logged_detail = detail_text or repr(e)
-    logger.opt(exception=e).error(
+    log.opt(exception=e).error(
         f"{response_text_prefix or GENERIC_UPSTREAM_ERROR}: {exc_type}: {logged_detail}"
     )
     if stream:

--- a/src/tests/unit/test_completions.py
+++ b/src/tests/unit/test_completions.py
@@ -1,3 +1,4 @@
+import asyncio
 import contextlib
 import json
 from unittest.mock import AsyncMock, MagicMock
@@ -848,6 +849,8 @@ async def test_stream_completion_budget_limit_exceeded_429(
     )
 
     mock_logger = mocker.patch("mlpa.core.completions.logger")
+    # stream_completion logs via logger.bind(...); route it back to the mock.
+    mock_logger.bind.return_value = mock_logger
 
     received_chunks = [
         chunk async for chunk in stream_completion(SAMPLE_REQUEST, mock_request)
@@ -895,6 +898,8 @@ async def test_stream_completion_budget_limit_exceeded_400(
     )
 
     mock_logger = mocker.patch("mlpa.core.completions.logger")
+    # stream_completion logs via logger.bind(...); route it back to the mock.
+    mock_logger.bind.return_value = mock_logger
 
     received_chunks = [
         chunk async for chunk in stream_completion(SAMPLE_REQUEST, mock_request)
@@ -934,6 +939,8 @@ async def test_stream_completion_rate_limit_exceeded(
     )
 
     mock_logger = mocker.patch("mlpa.core.completions.logger")
+    # stream_completion logs via logger.bind(...); route it back to the mock.
+    mock_logger.bind.return_value = mock_logger
 
     received_chunks = [
         chunk async for chunk in stream_completion(SAMPLE_REQUEST, mock_request)
@@ -968,6 +975,8 @@ async def test_stream_completion_context_window_exceeded(
     )
 
     mock_logger = mocker.patch("mlpa.core.completions.logger")
+    # stream_completion logs via logger.bind(...); route it back to the mock.
+    mock_logger.bind.return_value = mock_logger
 
     received_chunks = [
         chunk async for chunk in stream_completion(SAMPLE_REQUEST, mock_request)
@@ -1006,6 +1015,8 @@ async def test_stream_completion_invalid_model_name(
     )
 
     mock_logger = mocker.patch("mlpa.core.completions.logger")
+    # stream_completion logs via logger.bind(...); route it back to the mock.
+    mock_logger.bind.return_value = mock_logger
 
     received_chunks = [
         chunk async for chunk in stream_completion(SAMPLE_REQUEST, mock_request)
@@ -1043,6 +1054,8 @@ async def test_stream_completion_invalid_request_vertex(
     )
 
     mock_logger = mocker.patch("mlpa.core.completions.logger")
+    # stream_completion logs via logger.bind(...); route it back to the mock.
+    mock_logger.bind.return_value = mock_logger
 
     received_chunks = [
         chunk async for chunk in stream_completion(SAMPLE_REQUEST, mock_request)
@@ -1081,7 +1094,9 @@ async def test_stream_completion_400_non_rate_limit_error(
         status_code=400,
     )
 
-    mock_logger = mocker.patch("mlpa.core.utils.logger")
+    # raise_and_log uses the bound logger passed from stream_completion.
+    mock_logger = mocker.patch("mlpa.core.completions.logger")
+    mock_logger.bind.return_value = mock_logger
     mocker.patch.object(env, "MLPA_DEBUG", False)
 
     received_chunks = [
@@ -1111,7 +1126,9 @@ async def test_stream_completion_429_non_rate_limit_error(
         status_code=429,
     )
 
-    mock_logger = mocker.patch("mlpa.core.utils.logger")
+    # raise_and_log uses the bound logger passed from stream_completion.
+    mock_logger = mocker.patch("mlpa.core.completions.logger")
+    mock_logger.bind.return_value = mock_logger
     mocker.patch.object(env, "MLPA_DEBUG", False)
 
     received_chunks = [
@@ -1165,7 +1182,9 @@ async def test_stream_completion_429_invalid_json(
         status_code=429,
     )
 
-    mock_logger = mocker.patch("mlpa.core.utils.logger")
+    # raise_and_log uses the bound logger passed from stream_completion.
+    mock_logger = mocker.patch("mlpa.core.completions.logger")
+    mock_logger.bind.return_value = mock_logger
     mocker.patch.object(env, "MLPA_DEBUG", False)
 
     received_chunks = [
@@ -1616,3 +1635,31 @@ async def test_stream_mid_stream_error_binds_request_fields(
     assert rec["extra"]["user"] == SAMPLE_REQUEST.user
     assert rec["extra"]["model"] == SAMPLE_REQUEST.model
     assert rec["extra"]["service_type"] == SAMPLE_REQUEST.service_type
+
+
+async def test_stream_completion_aclose_from_separate_task_does_not_crash(
+    mocker, mock_request, metrics_spy
+):
+    """Closing the SSE generator from a different asyncio Task (what Starlette
+    does on client disconnect) must not raise ValueError from a contextvar token
+    reset in a foreign Context.
+    """
+    role_chunk = (
+        b'data: {"choices":[{"delta":{"role":"assistant","content":null}}]}\n\n'
+    )
+
+    async def _aiter_bytes():
+        yield role_chunk
+        yield b'data: {"choices":[{"delta":{"content":"hi"}}]}\n\n'
+
+    _patch_mock_stream_client(mocker, _aiter_bytes)
+
+    gen = stream_completion(SAMPLE_REQUEST, mock_request)
+    first = await gen.__anext__()
+    assert first == role_chunk
+
+    # Close from a separate task -> separate contextvars.Context.
+    await asyncio.create_task(gen.aclose())
+
+    assert _latency_count(metrics_spy, PrometheusResult.ABORT) == 1
+    assert _latency_count(metrics_spy, PrometheusResult.ERROR) == 0


### PR DESCRIPTION
## Context: 
#184 moved the loguru log-field binding inside the streaming generator so request fields (user/model/service_type) stay attached to mid-stream logs. It used logger.contextualize(**log_fields) wrapped around the SSE yield. That introduced a regression.

stream_completion is an async generator. When the client disconnects mid-stream, Starlette tears the generator down from a different asyncio Task than the one that drove it. contextualize sets a contextvars token on enter and runs context.reset(token) on exit. The reset then runs in a foreign Context and raises:

`ValueError: <Token ...loguru_context...>` was created in a different Context

Sentry started seeing this right after #184 merged: 17 events, all on the streaming path (stream_completion), in production. It's handled and 0 users affected (the client already left by the time teardown runs), so no broken responses, but it's a steady stream of "Task exception was never retrieved" noise and the contextvar never gets reset. The extra finally: await gen.aclose() #184 added also gives a second close path that can feed the older aclose(): already running error.

## Fix

Bind the fields with logger.bind(**log_fields) instead of logger.contextualize(...). bind returns a child logger with no token to reset, so teardown from any task is clean. This keeps #184's actual goal (fields stay attached during streaming) without the contextvar lifecycle.

- Collapsed the wrapper + inner generator back into one generator.
- Routed the in-generator log calls through the bound logger.
- Threaded the bound logger into raise_and_log via a new log= kwarg so mid-stream error logs keep the request fields.

get_completion and get_search are plain coroutines, not generators, so contextualize enter/exit stays in one context there. Left unchanged.

## QA

Added test_stream_completion_aclose_from_separate_task_does_not_crash: drives the generator one chunk, then closes it from a separate asyncio task (separate Context, what Starlette does on disconnect). Against the current code it raises the exact prod ValueError at context.reset(token); with the fix it closes cleanly and records one ABORT, zero ERROR.