### PR TITLE
feat(client-country-metric): AIPLAT-1020

### DIFF
--- a/src/mlpa/core/metrics.py
+++ b/src/mlpa/core/metrics.py
@@ -13,6 +13,9 @@ from mlpa.core.prometheus_metrics import (
     availability_outcome_for,
     metrics,
 )
+from mlpa.core.utils import clamp_country
+
+SEARCH_MODEL = "exa"
 
 
 def _chat_labels(req: AuthorizedChatRequest) -> dict[str, str]:
@@ -25,10 +28,20 @@ def _chat_labels(req: AuthorizedChatRequest) -> dict[str, str]:
 
 def _search_labels(req: AuthorizedSearchRequest) -> dict[str, str]:
     return {
-        "model": "exa",
+        "model": SEARCH_MODEL,
         "service_type": req.service_type,
         "purpose": req.purpose,
     }
+
+
+def record_request_country(
+    raw_country: str | None, *, service_type: str, model: str
+) -> None:
+    metrics.requests_by_country_total.labels(
+        service_type=service_type,
+        model=model,
+        client_country=clamp_country(raw_country),
+    ).inc()
 
 
 def record_chat_request_rejection(

--- a/src/mlpa/core/prometheus_metrics.py
+++ b/src/mlpa/core/prometheus_metrics.py
@@ -152,6 +152,7 @@ class PrometheusMetrics:
     # global request metrics
     in_progress_requests: Gauge
     requests_total: Counter
+    requests_by_country_total: Counter
     response_status_codes: Counter
     request_latency: Histogram
 
@@ -207,6 +208,13 @@ def build_metrics(registry: CollectorRegistry = REGISTRY) -> PrometheusMetrics:
             "mlpa_requests_total",
             "Total number of requests handled by the proxy.",
             ["method", "endpoint", "service_type", "purpose"],
+            registry=registry,
+        ),
+        requests_by_country_total=Counter(
+            "mlpa_requests_by_country_total",
+            "Chat and search requests by client country (edge-derived), service_type, and model. "
+            "Plain counter by design; country is kept off histograms to bound cardinality.",
+            ["service_type", "model", "client_country"],
             registry=registry,
         ),
         response_status_codes=Counter(

--- a/src/mlpa/core/utils.py
+++ b/src/mlpa/core/utils.py
@@ -21,6 +21,18 @@ from mlpa.core.logger import logger
 from mlpa.core.pg_services.services import app_attest_pg, litellm_pg
 from mlpa.core.prometheus_metrics import PrometheusResult, metrics
 
+_COUNTRY_RE = re.compile(r"[A-Z]{2}")
+
+
+def clamp_country(raw: str | None) -> str:
+    """Bound an edge-stamped client country to a 2-letter A-Z code, else "unknown".
+
+    Country is coarse, edge-derived geo (MLPA never sees the client IP) used only
+    for aggregate metrics, never per-user data or logs. The clamp also caps label
+    cardinality and blocks injection from a spoofed ``X-Geo-Country`` header.
+    """
+    return raw if raw and _COUNTRY_RE.fullmatch(raw) else "unknown"
+
 
 async def get_or_create_user(user_id: str):
     """Returns user info from LiteLLM, creating the user if they don't exist.

--- a/src/mlpa/run.py
+++ b/src/mlpa/run.py
@@ -26,7 +26,11 @@ from mlpa.core.config import (
 )
 from mlpa.core.http_client import close_http_client, get_http_client
 from mlpa.core.logger import logger, setup_logger
-from mlpa.core.metrics import record_chat_availability
+from mlpa.core.metrics import (
+    SEARCH_MODEL,
+    record_chat_availability,
+    record_request_country,
+)
 from mlpa.core.middleware import register_middleware
 from mlpa.core.openapi import customize_openapi
 from mlpa.core.pg_services.services import app_attest_pg, litellm_pg
@@ -201,6 +205,11 @@ async def chat_completion(
         AuthorizedChatRequest, Depends(authorize_chat_request)
     ],
 ):
+    record_request_country(
+        request.headers.get("X-Geo-Country"),
+        service_type=authorized_chat_request.service_type,
+        model=authorized_chat_request.model,
+    )
     user_id = authorized_chat_request.user
     if not user_id:
         raise HTTPException(
@@ -233,6 +242,11 @@ async def search(
         AuthorizedSearchRequest, Depends(authorize_search_request)
     ],
 ):
+    record_request_country(
+        request.headers.get("X-Geo-Country"),
+        service_type=authorized_search_request.service_type,
+        model=SEARCH_MODEL,
+    )
     if authorized_search_request.service_type not in env.SEARCH_ALLOWED_SERVICE_TYPES:
         raise HTTPException(
             status_code=400, detail="service-type header must be of type 'search'"

--- a/src/tests/integration/test_request_country.py
+++ b/src/tests/integration/test_request_country.py
@@ -1,0 +1,96 @@
+from unittest.mock import AsyncMock, patch
+
+from mlpa.core.metrics import SEARCH_MODEL
+from tests.consts import SAMPLE_REQUEST, TEST_FXA_TOKEN
+
+
+def _country_count(metrics_spy, **labels):
+    return metrics_spy.value("requests_by_country_total", **labels)
+
+
+def test_chat_records_country(mocked_client_integration, metrics_spy):
+    response = mocked_client_integration.post(
+        "/v1/chat/completions",
+        headers={
+            "authorization": f"Bearer {TEST_FXA_TOKEN}",
+            "service-type": "ai",
+            "purpose": "chat",
+            "X-Geo-Country": "DE",
+        },
+        json=SAMPLE_REQUEST.model_dump(),
+    )
+    assert response.status_code == 200
+    assert (
+        _country_count(
+            metrics_spy, service_type="ai", model="test-model", client_country="DE"
+        )
+        == 1.0
+    )
+
+
+def test_chat_missing_geo_header_is_unknown(mocked_client_integration, metrics_spy):
+    response = mocked_client_integration.post(
+        "/v1/chat/completions",
+        headers={
+            "authorization": f"Bearer {TEST_FXA_TOKEN}",
+            "service-type": "ai",
+            "purpose": "chat",
+        },
+        json=SAMPLE_REQUEST.model_dump(),
+    )
+    assert response.status_code == 200
+    assert (
+        _country_count(
+            metrics_spy, service_type="ai", model="test-model", client_country="unknown"
+        )
+        == 1.0
+    )
+
+
+def test_chat_spoofed_geo_header_is_clamped(mocked_client_integration, metrics_spy):
+    mocked_client_integration.post(
+        "/v1/chat/completions",
+        headers={
+            "authorization": f"Bearer {TEST_FXA_TOKEN}",
+            "service-type": "ai",
+            "purpose": "chat",
+            "X-Geo-Country": "ZZZ",
+        },
+        json=SAMPLE_REQUEST.model_dump(),
+    )
+    assert (
+        _country_count(
+            metrics_spy, service_type="ai", model="test-model", client_country="unknown"
+        )
+        == 1.0
+    )
+    assert (
+        _country_count(
+            metrics_spy, service_type="ai", model="test-model", client_country="ZZZ"
+        )
+        == 0.0
+    )
+
+
+def test_search_records_country_with_search_model(
+    mocked_client_integration, metrics_spy
+):
+    with patch("mlpa.run.get_search", new=AsyncMock(return_value={"results": []})):
+        mocked_client_integration.post(
+            "/v1/search",
+            headers={
+                "authorization": f"Bearer {TEST_FXA_TOKEN}",
+                "service-type": "search",
+                "X-Geo-Country": "US",
+            },
+            json={"query": "hello", "max_results": 3},
+        )
+    assert (
+        _country_count(
+            metrics_spy,
+            service_type="search",
+            model=SEARCH_MODEL,
+            client_country="US",
+        )
+        == 1.0
+    )

--- a/src/tests/unit/test_utils.py
+++ b/src/tests/unit/test_utils.py
@@ -5,6 +5,7 @@ from fastapi import HTTPException
 
 from mlpa.core.utils import (
     b64decode_safe,
+    clamp_country,
     is_context_window_error,
     is_invalid_model_name_error,
     is_invalid_request_error,
@@ -200,3 +201,23 @@ def test_is_invalid_request_error_no_match():
     assert is_invalid_request_error("Invalid request parameters") is False
     assert is_invalid_request_error("rate limit exceeded") is False
     assert is_invalid_request_error("") is False
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("DE", "DE"),
+        ("US", "US"),
+        ("de", "unknown"),
+        ("**", "unknown"),
+        ("--", "unknown"),
+        ("USA", "unknown"),
+        ("D", "unknown"),
+        ("D1", "unknown"),
+        ("", "unknown"),
+        (None, "unknown"),
+        ("DE; rm -rf", "unknown"),
+    ],
+)
+def test_clamp_country(raw, expected):
+    assert clamp_country(raw) == expected


### PR DESCRIPTION
Sister infra PR: https://github.com/mozilla/dataservices-infra/pull/2110

This adds a counter `mlpa_requests_by_country_total{service_type, model, client_country}`, incremented in the `/v1/chat/completions` and `/v1/search` handlers only (not the middleware, so it's scoped to product traffic).

 Country comes from the X-Geo-Country header that Fastly stamps from client.geo at the edge. clamp_country bounds it to a 2-letter code or unknown, which caps cardinality and blocks a spoofed header from injecting labels. Search has no model in the request, so it uses model="exa" (shared SEARCH_MODEL constant, same value the existing search metrics already use).

[AIPLAT-1020](https://mozilla-hub.atlassian.net/browse/AIPLAT-1020)