### PR TITLE
fix: MLPA disconnect causes Runtime Error

### DIFF
--- a/src/mlpa/core/completions.py
+++ b/src/mlpa/core/completions.py
@@ -190,6 +190,7 @@ async def stream_completion(
                         asyncio.CancelledError,
                         StopAsyncIteration,
                         httpx.ReadError,
+                        RuntimeError,
                     ):
                         await next_chunk_task
                     break

--- a/src/mlpa/core/completions.py
+++ b/src/mlpa/core/completions.py
@@ -192,8 +192,6 @@ async def stream_completion(
                         httpx.ReadError,
                     ):
                         await next_chunk_task
-                    with contextlib.suppress(httpx.ReadError):
-                        await response.aclose()
                     break
 
                 try:
@@ -305,6 +303,7 @@ async def stream_completion(
                 asyncio.CancelledError,
                 StopAsyncIteration,
                 httpx.ReadError,
+                RuntimeError,
             ):
                 await next_chunk_task
         # Cancel the disconnect watcher and wait for it to finish to avoid

--- a/src/tests/unit/test_completions.py
+++ b/src/tests/unit/test_completions.py
@@ -1,6 +1,7 @@
 import asyncio
 import contextlib
 import json
+from typing import Callable
 from unittest.mock import AsyncMock, MagicMock
 
 import httpx
@@ -1354,21 +1355,41 @@ def _assert_error_latency(spy) -> None:
     assert _latency_count(spy, PrometheusResult.ERROR) == 1
 
 
-def _patch_mock_stream_client(mocker, aiter_bytes_fn, capture: dict | None = None):
+def _patch_mock_stream_client(
+    mocker,
+    aiter_bytes_fn,
+    capture: dict | None = None,
+    aclose_impl: Callable | None = None,
+):
     """Patch get_http_client with a mock that streams via aiter_bytes_fn.
 
     capture: if provided, stream call kwargs are merged into it (for timeout inspection).
+    alongside close calls which where executed in the stream
     """
     mock_response = MagicMock()
     mock_response.raise_for_status.return_value = None
     mock_response.headers = {}
     mock_response.aiter_bytes = aiter_bytes_fn
 
+    async def _aclose():
+        if capture is not None:
+            if "close_count" not in capture:
+                capture["close_count"] = 1
+            else:
+                capture["close_count"] += 1
+        if aclose_impl is not None:
+            await aclose_impl()
+
+    mock_response.aclose = _aclose
+
     @contextlib.asynccontextmanager
     async def _mock_stream(*args, **kwargs):
-        if capture is not None:
-            capture.update(kwargs)
-        yield mock_response
+        try:
+            if capture is not None:
+                capture.update(kwargs)
+            yield mock_response
+        finally:
+            await mock_response.aclose()
 
     mock_client = MagicMock()
     mock_client.stream = _mock_stream
@@ -1663,3 +1684,60 @@ async def test_stream_completion_aclose_from_separate_task_does_not_crash(
 
     assert _latency_count(metrics_spy, PrometheusResult.ABORT) == 1
     assert _latency_count(metrics_spy, PrometheusResult.ERROR) == 0
+
+
+async def test_response_aclose_called_once_on_disconnect(mocker, mock_request):
+    role_chunk = b'data: {"choices":[{"delta":{"role":"assistant"}}]}\n\n'
+
+    async def _aiter_bytes():
+        yield role_chunk
+        await asyncio.Event().wait()  # blocks: simulate waiting on next chunk
+
+    capture = {}
+    _patch_mock_stream_client(mocker, _aiter_bytes, capture)
+    mock_request.is_disconnected = AsyncMock(side_effect=[False, True])
+
+    received = [c async for c in stream_completion(SAMPLE_REQUEST, mock_request)]
+
+    assert received == [role_chunk]
+    assert capture.get("close_count") == 1, (
+        f"expected response.aclose() to be called exactly once, got {capture.get('close_count')}"
+    )
+
+
+async def test_pending_task_cancel_runtime_error_suppressed(mocker, mock_request):
+    started = asyncio.Event()
+
+    async def _aiter_bytes():
+        try:
+            started.set()
+            await asyncio.Event().wait()  # blocks until next_chunk_task is cancelled
+            yield b""  # pragma: no cover - unreachable, keeps this an async generator
+        except asyncio.CancelledError:
+            raise RuntimeError("aclose(): asynchronous generator is already running")
+
+    _patch_mock_stream_client(mocker, _aiter_bytes)
+    mock_request.is_disconnected = AsyncMock(return_value=False)
+
+    async def _consume():
+        async for _ in stream_completion(SAMPLE_REQUEST, mock_request):
+            pass
+
+    records = []
+    sink_id = loguru_logger.add(records.append, level="DEBUG", format="{message}")
+    task = asyncio.create_task(_consume())
+    try:
+        await started.wait()
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+    finally:
+        loguru_logger.remove(sink_id)
+
+    error_records = [
+        r.record["message"] for r in records if r.record["level"].name == "ERROR"
+    ]
+    assert error_records == [], (
+        "a cancelled request must propagate CancelledError cleanly, not log "
+        f"an ERROR for teardown noise, got: {error_records}"
+    )


### PR DESCRIPTION
## What's Changed
- Removes manual await `response.aclose()` in cancel branch
- Suppresses runtime errors in httpx teardown
- Added tracking to capture dict to allow mocks to track how many times the stream was closed
- Added tests to verify that stream close call and validate that errors are not thrown

## QA Path
Added two test cases, added a test case to ensure that the stream is called once per close and that Runtime error is not thrown. 

### Close Count
In this test we run the close count validation on the old logic versus the new logic

Old Logic:
<img width="1444" height="202" alt="image" src="https://github.com/user-attachments/assets/05fd1063-9986-411b-bf14-be605979a810" />

New Logic:
<img width="1429" height="170" alt="image" src="https://github.com/user-attachments/assets/d6e4281f-9d6b-4492-a449-167340197c06" />


### Runtime error
In this test we validate that runtime errors are suppressed in the httpx teardown

Old Logic:
<img width="1062" height="181" alt="image" src="https://github.com/user-attachments/assets/0a298705-7e8e-4405-a341-78accad22343" />

New Logic:
<img width="1430" height="168" alt="image" src="https://github.com/user-attachments/assets/f7c8736d-bb5c-449f-ad86-28f3ff978a5e" />


## Related Tickets & Documents
[AIPLAT-1124](https://mozilla-hub.atlassian.net/browse/AIPLAT-1124?atlOrigin=eyJpIjoiNTFiZGJlN2YzN2EzNGY2NGI3NDU3MjU5YmE2ZjVmZjIiLCJwIjoiaiJ9)