### PR TITLE
feat: make httpx/asyncpg debug logging lazy

### DIFF
--- a/src/mlpa/core/logger.py
+++ b/src/mlpa/core/logger.py
@@ -102,30 +102,36 @@ def _truncate_mapping(mapping, limit=5):
     return result
 
 
+def _httpx_params_repr(params):
+    return _truncate_mapping(params) if isinstance(params, dict) else _truncate(params)
+
+
+def _httpx_json_repr(json_data):
+    if isinstance(json_data, dict) and "messages" in json_data:
+        json_data = dict(json_data)
+        json_data["messages"] = "[...]"
+    return (
+        _truncate_mapping(json_data)
+        if isinstance(json_data, dict)
+        else _truncate(json_data)
+    )
+
+
 def _enable_httpx_logging():
     if not env.HTTPX_LOGGING:
         return
 
     def _build_wrapper(method_name, original):
+        method_label = method_name.upper()
+
         async def _wrapper(self, *args, **kwargs):
             url = args[0] if args else kwargs.get("url")
-            params = kwargs.get("params")
-            json_data = kwargs.get("json")
-            if isinstance(json_data, dict) and "messages" in json_data:
-                json_data = dict(json_data)
-                json_data["messages"] = "[...]"
-            params_repr = (
-                _truncate_mapping(params)
-                if isinstance(params, dict)
-                else _truncate(params)
-            )
-            json_repr = (
-                _truncate_mapping(json_data)
-                if isinstance(json_data, dict)
-                else _truncate(json_data)
-            )
-            logger.debug(
-                f"HTTPX {method_name.upper()} request -> {url=} {params_repr=} {json_repr=}",
+            logger.opt(lazy=True).debug(
+                "HTTPX {} request -> url={!r} params_repr={!r} json_repr={!r}",
+                lambda: method_label,
+                lambda: url,
+                lambda: _httpx_params_repr(kwargs.get("params")),
+                lambda: _httpx_json_repr(kwargs.get("json")),
             )
             try:
                 response = await original(self, *args, **kwargs)
@@ -137,8 +143,11 @@ def _enable_httpx_logging():
                     f"{type(exc).__name__}: {exc!r}"
                 )
                 raise
-            logger.debug(
-                f"HTTPX {method_name.upper()} response <- {url=} {response.status_code=}",
+            logger.opt(lazy=True).debug(
+                "HTTPX {} response <- url={!r} status_code={}",
+                lambda: method_label,
+                lambda: url,
+                lambda: response.status_code,
             )
             return response
 
@@ -165,16 +174,21 @@ def _enable_asyncpg_logging():
         return
 
     async def _execute_wrapper(self, query, *args, **kwargs):
-        logger.debug(
-            f"ASYNCPG execute -> {query=} {args=}",
+        logger.opt(lazy=True).debug(
+            "ASYNCPG execute -> query={!r} args={!r}",
+            lambda: query,
+            lambda: args,
         )
         try:
             result = await original_execute(self, query, *args, **kwargs)
         except Exception:
             logger.error(f"ASYNCPG execute failed -> {query=}")
             raise
-        logger.debug(
-            f"ASYNCPG execute <- {query=} {args=}{result=}",
+        logger.opt(lazy=True).debug(
+            "ASYNCPG execute <- query={!r} args={!r} result={!r}",
+            lambda: query,
+            lambda: args,
+            lambda: result,
         )
         return result
 

--- a/src/tests/unit/test_logger.py
+++ b/src/tests/unit/test_logger.py
@@ -1,11 +1,12 @@
 import contextlib
 
+import asyncpg
 import httpx
 import pytest
 from loguru import logger as loguru_logger
 
 from mlpa.core.config import env
-from mlpa.core.logger import _enable_httpx_logging
+from mlpa.core.logger import _enable_asyncpg_logging, _enable_httpx_logging
 
 
 @contextlib.contextmanager
@@ -16,6 +17,15 @@ def _capture_logs():
         yield records
     finally:
         loguru_logger.remove(sink_id)
+
+
+@contextlib.contextmanager
+def _disable_logger_module():
+    loguru_logger.disable("mlpa.core.logger")
+    try:
+        yield
+    finally:
+        loguru_logger.enable("mlpa.core.logger")
 
 
 async def test_httpx_wrapper_logs_exc_type_on_transport_failure(mocker):
@@ -56,3 +66,86 @@ async def test_httpx_wrapper_logs_exc_type_on_transport_failure(mocker):
     msg = failures[0]
     assert "ConnectError" in msg
     assert url in msg
+
+
+async def test_httpx_debug_payload_build_is_lazy_when_debug_is_disabled(mocker):
+    mocker.patch.object(env, "HTTPX_LOGGING", True)
+    truncate_mapping = mocker.patch(
+        "mlpa.core.logger._truncate_mapping",
+        side_effect=AssertionError("debug payload should not be built"),
+    )
+
+    before_get = httpx.AsyncClient.get
+    before_post = httpx.AsyncClient.post
+    try:
+        _enable_httpx_logging()
+
+        transport = httpx.MockTransport(lambda request: httpx.Response(200))
+        url = "http://litellm:8000/v1/chat/completions"
+        with _disable_logger_module():
+            async with httpx.AsyncClient(transport=transport) as client:
+                await client.post(
+                    url,
+                    params={"user_id": "test-user"},
+                    json={
+                        "messages": [{"role": "user", "content": "secret"}],
+                        "model": "exa",
+                    },
+                )
+    finally:
+        httpx.AsyncClient.get = before_get
+        httpx.AsyncClient.post = before_post
+
+    truncate_mapping.assert_not_called()
+
+
+async def test_asyncpg_debug_args_build_is_lazy_when_debug_is_disabled(mocker):
+    mocker.patch.object(env, "ASYNCPG_LOGGING", True)
+
+    class UnreprableArg:
+        def __repr__(self):
+            raise AssertionError("debug args should not be formatted")
+
+    async def _execute(self, query, *args, **kwargs):
+        return "OK"
+
+    before_execute = asyncpg.connection.Connection.execute
+    try:
+        asyncpg.connection.Connection.execute = _execute
+        _enable_asyncpg_logging()
+
+        with _disable_logger_module():
+            result = await asyncpg.connection.Connection.execute(
+                object(), "SELECT $1", UnreprableArg()
+            )
+    finally:
+        asyncpg.connection.Connection.execute = before_execute
+
+    assert result == "OK"
+
+
+async def test_asyncpg_wrapper_logs_query_on_execute_failure(mocker):
+    mocker.patch.object(env, "ASYNCPG_LOGGING", True)
+
+    async def _execute(self, query, *args, **kwargs):
+        raise RuntimeError("bad query")
+
+    before_execute = asyncpg.connection.Connection.execute
+    try:
+        asyncpg.connection.Connection.execute = _execute
+        _enable_asyncpg_logging()
+
+        query = "SELECT bad"
+        with _capture_logs() as records:
+            with pytest.raises(RuntimeError):
+                await asyncpg.connection.Connection.execute(object(), query)
+    finally:
+        asyncpg.connection.Connection.execute = before_execute
+
+    failures = [
+        item.record["message"]
+        for item in records
+        if item.record["level"].name == "ERROR"
+        and "ASYNCPG execute failed" in item.record["message"]
+    ]
+    assert failures == [f"ASYNCPG execute failed -> query='{query}'"]

--- a/src/tests/unit/test_logger.py
+++ b/src/tests/unit/test_logger.py
@@ -1,10 +1,12 @@
 import contextlib
+import sys
 
 import asyncpg
 import httpx
 import pytest
 from loguru import logger as loguru_logger
 
+from mlpa.core import logger as logger_module
 from mlpa.core.config import env
 from mlpa.core.logger import _enable_asyncpg_logging, _enable_httpx_logging
 
@@ -20,12 +22,15 @@ def _capture_logs():
 
 
 @contextlib.contextmanager
-def _disable_logger_module():
-    loguru_logger.disable("mlpa.core.logger")
+def _capture_only_logs_at_level(level):
+    records = []
+    loguru_logger.remove()
+    sink_id = loguru_logger.add(records.append, level=level, format="{message}")
     try:
-        yield
+        yield records
     finally:
-        loguru_logger.enable("mlpa.core.logger")
+        loguru_logger.remove(sink_id)
+        loguru_logger.add(sys.stderr, level="DEBUG")
 
 
 async def test_httpx_wrapper_logs_exc_type_on_transport_failure(mocker):
@@ -68,12 +73,18 @@ async def test_httpx_wrapper_logs_exc_type_on_transport_failure(mocker):
     assert url in msg
 
 
-async def test_httpx_debug_payload_build_is_lazy_when_debug_is_disabled(mocker):
+@pytest.mark.parametrize(
+    ("loguru_level", "expected_truncate_calls"),
+    [
+        ("INFO", 0),
+        ("DEBUG", 2),
+    ],
+)
+async def test_httpx_debug_payload_build_follows_loguru_level(
+    mocker, loguru_level, expected_truncate_calls
+):
     mocker.patch.object(env, "HTTPX_LOGGING", True)
-    truncate_mapping = mocker.patch(
-        "mlpa.core.logger._truncate_mapping",
-        side_effect=AssertionError("debug payload should not be built"),
-    )
+    truncate_mapping = mocker.spy(logger_module, "_truncate_mapping")
 
     before_get = httpx.AsyncClient.get
     before_post = httpx.AsyncClient.post
@@ -82,7 +93,7 @@ async def test_httpx_debug_payload_build_is_lazy_when_debug_is_disabled(mocker):
 
         transport = httpx.MockTransport(lambda request: httpx.Response(200))
         url = "http://litellm:8000/v1/chat/completions"
-        with _disable_logger_module():
+        with _capture_only_logs_at_level(loguru_level) as records:
             async with httpx.AsyncClient(transport=transport) as client:
                 await client.post(
                     url,
@@ -96,15 +107,37 @@ async def test_httpx_debug_payload_build_is_lazy_when_debug_is_disabled(mocker):
         httpx.AsyncClient.get = before_get
         httpx.AsyncClient.post = before_post
 
-    truncate_mapping.assert_not_called()
+    assert truncate_mapping.call_count == expected_truncate_calls
+    request_logs = [
+        item.record["message"]
+        for item in records
+        if "HTTPX POST request ->" in item.record["message"]
+    ]
+    if loguru_level == "DEBUG":
+        assert len(request_logs) == 1
+        assert "test-user" in request_logs[0]
+    else:
+        assert request_logs == []
 
 
-async def test_asyncpg_debug_args_build_is_lazy_when_debug_is_disabled(mocker):
+@pytest.mark.parametrize(
+    ("loguru_level", "expect_debug_logs"),
+    [
+        ("INFO", False),
+        ("DEBUG", True),
+    ],
+)
+async def test_asyncpg_debug_args_build_follows_loguru_level(
+    mocker, loguru_level, expect_debug_logs
+):
     mocker.patch.object(env, "ASYNCPG_LOGGING", True)
+    repr_calls = 0
 
-    class UnreprableArg:
+    class TrackedArg:
         def __repr__(self):
-            raise AssertionError("debug args should not be formatted")
+            nonlocal repr_calls
+            repr_calls += 1
+            return "TrackedArg('test-user')"
 
     async def _execute(self, query, *args, **kwargs):
         return "OK"
@@ -114,14 +147,26 @@ async def test_asyncpg_debug_args_build_is_lazy_when_debug_is_disabled(mocker):
         asyncpg.connection.Connection.execute = _execute
         _enable_asyncpg_logging()
 
-        with _disable_logger_module():
+        with _capture_only_logs_at_level(loguru_level) as records:
             result = await asyncpg.connection.Connection.execute(
-                object(), "SELECT $1", UnreprableArg()
+                object(), "SELECT $1", TrackedArg()
             )
     finally:
         asyncpg.connection.Connection.execute = before_execute
 
     assert result == "OK"
+    debug_logs = [
+        item.record["message"]
+        for item in records
+        if "ASYNCPG execute" in item.record["message"]
+    ]
+    if expect_debug_logs:
+        assert len(debug_logs) == 2
+        assert repr_calls >= 2
+        assert all("TrackedArg('test-user')" in message for message in debug_logs)
+    else:
+        assert debug_logs == []
+        assert repr_calls == 0
 
 
 async def test_asyncpg_wrapper_logs_query_on_execute_failure(mocker):


### PR DESCRIPTION
## What's new

  - Make HTTPX request/response debug logs lazy with `logger.opt(lazy=True)`.
  - Make asyncpg execute debug logs lazy for `query`, `args`, and `result`.
  - Move HTTPX JSON body redaction/truncation behind the lazy DEBUG log path.
  - Keep HTTPX/asyncpg error logs unconditional, so transport/DB failures still log at
  INFO+.

When `LOGURU_LEVEL=INFO`, DEBUG log payloads are no longer formatted before
  being dropped. This saves a small amount of CPU and avoids formatting request args/
  user IDs unless DEBUG logging is intentionally enabled.
https://mozilla-hub.atlassian.net/browse/AIPLAT-1143