### PR TITLE
fix: allow empty service type and purpose (no clamp)

### DIFF
--- a/src/mlpa/core/utils.py
+++ b/src/mlpa/core/utils.py
@@ -22,32 +22,6 @@ from mlpa.core.logger import logger
 from mlpa.core.pg_services.services import app_attest_pg, litellm_pg
 from mlpa.core.prometheus_metrics import PrometheusResult, metrics
 
-INVALID_MODEL_LABEL = "invalid_model"
-
-
-def clamp_model(model: str) -> str:
-    return model if model in env.valid_model_labels else INVALID_MODEL_LABEL
-
-
-def clamp_service_type(raw: str) -> str:
-    return raw if raw in env.valid_service_types_set else "other"
-
-
-def clamp_purpose(raw: str) -> str:
-    return raw if raw in env.valid_purposes_set else "other"
-
-
-def clamp_country(raw: str | None) -> str:
-    """Bound an edge-stamped client country to a known country code, else "unknown".
-
-    Country is coarse, edge-derived geo (MLPA never sees the client IP) used only
-    for aggregate metrics, never per-user data or logs. The clamp also caps label
-    cardinality and blocks injection from a spoofed ``X-Geo-Country`` header.
-    """
-    return raw if raw in COUNTRY_CODES else "unknown"
-
-
-UNKNOWN_METHOD_LABEL = "INVALID"
 KNOWN_HTTP_METHODS = frozenset(
     {
         "DELETE",
@@ -61,9 +35,31 @@ KNOWN_HTTP_METHODS = frozenset(
 )
 
 
+def clamp_model(model: str) -> str:
+    return model if model in env.valid_model_labels else "invalid"
+
+
+def clamp_service_type(raw: str) -> str:
+    return raw if raw == "" or raw in env.valid_service_types_set else "other"
+
+
+def clamp_purpose(raw: str) -> str:
+    return raw if raw == "" or raw in env.valid_purposes_set else "other"
+
+
+def clamp_country(raw: str | None) -> str:
+    """Bound an edge-stamped client country to a known country code, else "unknown".
+
+    Country is coarse, edge-derived geo (MLPA never sees the client IP) used only
+    for aggregate metrics, never per-user data or logs. The clamp also caps label
+    cardinality and blocks injection from a spoofed ``X-Geo-Country`` header.
+    """
+    return raw if raw in COUNTRY_CODES else "unknown"
+
+
 def clamp_request_method(method: str) -> str:
     normalized = method.upper()
-    return normalized if normalized in KNOWN_HTTP_METHODS else UNKNOWN_METHOD_LABEL
+    return normalized if normalized in KNOWN_HTTP_METHODS else "INVALID"
 
 
 async def get_or_create_user(user_id: str):

--- a/src/tests/integration/test_request_country.py
+++ b/src/tests/integration/test_request_country.py
@@ -1,7 +1,7 @@
 from unittest.mock import AsyncMock, patch
 
 from mlpa.core.metrics import SEARCH_MODEL
-from mlpa.core.utils import INVALID_MODEL_LABEL, clamp_model
+from mlpa.core.utils import clamp_model
 from tests.consts import SAMPLE_REQUEST, TEST_FXA_TOKEN
 
 
@@ -127,12 +127,12 @@ def test_chat_unknown_model_country_uses_invalid_model_bucket(
         json=_chat_payload("not-a-configured-model"),
     )
 
-    assert clamp_model("not-a-configured-model") == INVALID_MODEL_LABEL
+    assert clamp_model("not-a-configured-model") == "invalid"
     assert (
         _country_count(
             metrics_spy,
             service_type="ai",
-            model=INVALID_MODEL_LABEL,
+            model="invalid",
             client_country="CA",
         )
         == 1.0

--- a/src/tests/integration/test_request_size_limit.py
+++ b/src/tests/integration/test_request_size_limit.py
@@ -1,7 +1,6 @@
 import json
 
 from mlpa.core.config import env
-from mlpa.core.utils import INVALID_MODEL_LABEL
 from tests.consts import TEST_FXA_TOKEN
 
 
@@ -67,7 +66,7 @@ def test_request_size_over_limit(mocked_client_integration, metrics_spy):
             "chat_availability",
             outcome="excluded",
             reason="payload_too_large",
-            model=INVALID_MODEL_LABEL,
+            model="invalid",
             service_type="ai",
             purpose="chat",
         )

--- a/src/tests/unit/test_metrics.py
+++ b/src/tests/unit/test_metrics.py
@@ -12,7 +12,7 @@ from mlpa.core.prometheus_metrics import (
     PrometheusRejectionReason,
     PrometheusResult,
 )
-from mlpa.core.utils import INVALID_MODEL_LABEL, clamp_model
+from mlpa.core.utils import clamp_model
 
 
 def _chat_request(model: str = "openai/gpt-4o") -> AuthorizedChatRequest:
@@ -58,8 +58,9 @@ def test_tool_metrics_are_aggregated_without_tool_name(metrics_spy):
 
 def test_unknown_models_are_bucketed_on_failure_side_metrics(metrics_spy):
     req = _chat_request(model="unconfigured-model-from-request")
+    invalid_model_label = clamp_model(req.model)
     labels = {
-        "model": INVALID_MODEL_LABEL,
+        "model": invalid_model_label,
         "service_type": req.service_type,
         "purpose": req.purpose,
     }
@@ -74,7 +75,7 @@ def test_unknown_models_are_bucketed_on_failure_side_metrics(metrics_spy):
         metrics_spy.value(
             "requests_by_country_total",
             service_type=req.service_type,
-            model=INVALID_MODEL_LABEL,
+            model=invalid_model_label,
             client_country="US",
         )
         == 1
@@ -128,6 +129,57 @@ def test_invalid_service_type_and_purpose_are_bucketed(metrics_spy):
             **labels,
         )
         == 1
+    )
+    assert (
+        metrics_spy.value(
+            "chat_availability",
+            outcome="excluded",
+            reason=AvailabilityReason.INVALID_REQUEST,
+            **labels,
+        )
+        == 1
+    )
+    assert (
+        metrics_spy.histogram_count(
+            "chat_completion_latency",
+            result=PrometheusResult.ERROR,
+            **labels,
+        )
+        == 1
+    )
+
+
+def test_missing_service_type_and_purpose_are_not_bucketed_as_other(metrics_spy):
+    req = _chat_request(model="openai/gpt-4o")
+    req.service_type = ""
+    req.purpose = ""
+
+    record_chat_request_rejection(req, PrometheusRejectionReason.INVALID_REQUEST)
+    record_chat_availability(req, AvailabilityReason.INVALID_REQUEST)
+    record_completion_latency(req, PrometheusResult.ERROR, 0.1)
+
+    labels = {
+        "model": req.model,
+        "service_type": "",
+        "purpose": "",
+    }
+    assert (
+        metrics_spy.value(
+            "chat_request_rejections",
+            reason=PrometheusRejectionReason.INVALID_REQUEST,
+            **labels,
+        )
+        == 1
+    )
+    assert (
+        metrics_spy.value(
+            "chat_request_rejections",
+            reason=PrometheusRejectionReason.INVALID_REQUEST,
+            model=req.model,
+            service_type="other",
+            purpose="other",
+        )
+        == 0
     )
     assert (
         metrics_spy.value(

--- a/src/tests/unit/test_utils.py
+++ b/src/tests/unit/test_utils.py
@@ -6,6 +6,8 @@ from fastapi import HTTPException
 from mlpa.core.utils import (
     b64decode_safe,
     clamp_country,
+    clamp_purpose,
+    clamp_service_type,
     is_context_window_error,
     is_invalid_model_name_error,
     is_invalid_request_error,
@@ -201,6 +203,32 @@ def test_is_invalid_request_error_no_match():
     assert is_invalid_request_error("Invalid request parameters") is False
     assert is_invalid_request_error("rate limit exceeded") is False
     assert is_invalid_request_error("") is False
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("", ""),
+        ("ai", "ai"),
+        ("memories", "memories"),
+        ("not-a-service-type", "other"),
+    ],
+)
+def test_clamp_service_type_preserves_missing_value(raw, expected):
+    assert clamp_service_type(raw) == expected
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("", ""),
+        ("chat", "chat"),
+        ("memory-generation", "memory-generation"),
+        ("not-a-purpose", "other"),
+    ],
+)
+def test_clamp_purpose_preserves_missing_value(raw, expected):
+    assert clamp_purpose(raw) == expected
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## What's new

- Allow empty service type and purpose (do not default to `other`)
- Small cleanup and code consistency