### PR TITLE
chore: Add dependabot config for uv dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+updates:
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+    groups:
+      # Group minor and patch updates into one PR.
+      # Major updates remain as individual PRs.
+      minor-and-patch:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+    # Limit the number of concurrent version-update PRs.
+    # This does not limit dependencies per grouped PR.
+    open-pull-requests-limit: 5


### PR DESCRIPTION
## What's New

- Adds `.github/dependabot.yml` using the native `uv` package system
- Checks weekly for dependency updates
- Minor and patch updates are grouped as single PRs (major updates remain their own individual PRs)
- All generated PRs are review-gated. There will be at most **5** `version-update` PRs open.

## Context

This PR is part of the changeset for Jira ticket [AIPLAT-909](https://mozilla-hub.atlassian.net/browse/AIPLAT-909). The ticket specifies using the [Renovate GitHub app](https://github.com/apps/renovate), but Renovate is [conditionally approved](https://github.com/MoCo-GHE-Admin/Approved-GHE-Add-Ons/blob/main/Applications/renovate.md) and not installed in the `Firefox-AI` org.

This PR tests Dependabot's native `uv` support first since it needs no app install or approval. Whether it can rewrite MLPA's exact == pins is unverified. This PR helps us determine if this is the case.
- If it works, the ticket's requirements are met without a Renovate exception.
- If not, the job logs are the evidence package for requesting one.

**Known limitations**:
- `dependency-type` grouping (production vs development) is not supported for the `uv` ecosystem. All deps treated as production (see https://github.com/dependabot/dependabot-core/issues/13202)
- Dependabot classifies update types positionally, so **pre-1.0** jumps (e.g. **0.35** to **0.51**) land as "minor" or "patch."
  - This config follows the ticket's requested grouping. Package-specific exclusions can be added after observing the PRs.
- MLPA has **31** outdated exact-pinned direct deps.
  - The 5-PR limit caps concurrent PRs, not the number of deps in a grouped PR.
  - The first minor/patch PR may be large.

## QA

**Testable after merge**:
1. Open Insights > Dependency graph > Dependabot
2. Run a manual update check for the `uv` ecosystem
3. Review job logs and any resulting PRs:
   - The update job runs successfully under MLPA's `>=0.10,<0.12`  `uv` requirement
   - It detects outdated dependencies expressed with exact == pins
   - It updates `pyproject.toml`
   - It updates `uv.lock`
   - The resulting PR(s) pass linters and tests, including the uv-lock hook
  - How minor/patch grouping behaves with the current backlog
  - Whether the `pyfxa`  git dependency is recognized, ignored, or affects the job

## Related

- [AIPLAT-909](https://mozilla-hub.atlassian.net/browse/AIPLAT-909)
- [Dependabot uv docs](https://docs.astral.sh/uv/guides/integration/dependabot/)
- [dependency-type limitation](https://github.com/dependabot/dependabot-core/issues/13202)