### PR TITLE
feat: add release candidate tagging workflow

### DIFF
--- a/.github/workflows/tag-release-candidate.yml
+++ b/.github/workflows/tag-release-candidate.yml
@@ -4,15 +4,16 @@ on:
   workflow_dispatch:
     inputs:
       commit_sha:
-        description: "Full commit SHA on main that the image was built from"
+        description: "Full 40-character commit SHA from a merged main commit (copy from the commit page on GitHub or `git log`)"
         required: true
         type: string
       rc_number:
-        description: "Release candidate number (the N in vX.Y.Z-rc.N)"
+        description: "Release candidate number, e.g. 1 for vX.Y.Z-rc.1. Increment for each new candidate of the same version"
         required: true
         type: string
 
 concurrency:
+  # Shared with the stable promotion workflow so the two cannot mutate tags at the same time
   group: mlpa-image-promotion
   cancel-in-progress: false
 
@@ -40,11 +41,11 @@ jobs:
         run: |
           set -euo pipefail
           if [[ ! "$COMMIT_SHA" =~ ^[0-9a-fA-F]{40}$ ]]; then
-            echo "::error::commit_sha must be a full 40-character hex SHA"
+            echo "::error::commit_sha must be a full 40-character hex SHA, got: '$COMMIT_SHA'"
             exit 1
           fi
           if [[ ! "$RC_NUMBER" =~ ^[1-9][0-9]*$ ]]; then
-            echo "::error::rc_number must be a positive integer"
+            echo "::error::rc_number must be a positive integer with no leading zeros, got: '$RC_NUMBER'"
             exit 1
           fi
 
@@ -52,20 +53,23 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.commit_sha }}
-          # Full history so the on-main check below can fetch origin/main.
-          # persist-credentials: false is fine while the repo is public (the fetch
-          # needs no auth); a private repo would need a token here instead.
+          # Full history: needed to fetch and compare against `origin/main` below
           fetch-depth: 0
           persist-credentials: false
 
+      # The short-SHA image tags we look up are only created by pushes to `main`
+      # We confirm the candidate actually landed there before looking it up in GAR
       - name: Verify candidate is on main
         env:
           COMMIT_SHA: ${{ inputs.commit_sha }}
         run: |
           set -euo pipefail
+
+          # The explicit refspec guarantees `origin/main` is up-to-date locally
           git fetch --no-tags origin "+refs/heads/main:refs/remotes/origin/main"
+
           if ! git merge-base --is-ancestor "$COMMIT_SHA" origin/main; then
-            echo "::error::Commit $COMMIT_SHA is not an ancestor of main"
+            echo "::error::Commit $COMMIT_SHA is not on main. Has it been merged?"
             exit 1
           fi
 
@@ -77,19 +81,24 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Use the same short SHA the build used to tag the image.
+          # Recompute the tag w/ the same command the build used (length can exceed 10)
           SOURCE_TAG="$(git rev-parse --short=10 "$COMMIT_SHA")"
 
+          # Read the version from `pyproject.toml` as of the candidate commit
           VERSION="$(python3 -c "import tomllib, pathlib; print(tomllib.loads(pathlib.Path('pyproject.toml').read_text())['project']['version'])")"
+
+          # Strict semver with no leading zeros, so the eventual stable vX.Y.Z promotion is a valid prod tag
           if [[ ! "$VERSION" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
             echo "::error::project.version '$VERSION' is not a valid X.Y.Z version"
             exit 1
           fi
 
+          RC_TAG="v${VERSION}-rc.${RC_NUMBER}"
+
           echo "source_tag=${SOURCE_TAG}" >> "$GITHUB_OUTPUT"
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
-          echo "rc_tag=v${VERSION}-rc.${RC_NUMBER}" >> "$GITHUB_OUTPUT"
-          echo "Source tag: ${SOURCE_TAG}  ->  RC tag: v${VERSION}-rc.${RC_NUMBER}"
+          echo "rc_tag=${RC_TAG}" >> "$GITHUB_OUTPUT"
+          echo "Source tag: ${SOURCE_TAG}  ->  RC tag: ${RC_TAG}"
 
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
@@ -110,15 +119,18 @@ jobs:
           IMAGE="${GAR_LOCATION}-docker.pkg.dev/${GCP_PROJECT_ID}/${GAR_REPOSITORY}/${GAR_NAME}"
 
           # Return the image digest for a ref, or empty if it doesn't resolve.
+          # Errors are silenced, i.e., an empty digest does not distinguish
+          # a missing image from an API failure.
           get_digest() {
             gcloud artifacts docker images describe "$1" \
               --format='value(image_summary.digest)' 2>/dev/null || true
           }
 
-          # Source image must exist — stop if we can't resolve its digest.
+          # The source image must exist
           SOURCE_DIGEST="$(get_digest "${IMAGE}:${SOURCE_TAG}")"
           if [[ -z "$SOURCE_DIGEST" ]]; then
-            echo "::error::Source image ${IMAGE}:${SOURCE_TAG} not found. Was this commit built on main?"
+            echo "::error::Source image ${IMAGE}:${SOURCE_TAG} could not be resolved."
+            echo "::error::It may not exist, or the GAR lookup may have failed. Confirm the build for this commit completed."
             exit 1
           fi
           if [[ ! "$SOURCE_DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]; then
@@ -127,10 +139,10 @@ jobs:
           fi
           echo "Source: ${IMAGE}:${SOURCE_TAG} -> ${SOURCE_DIGEST}"
 
-          # Use `tags list` (not `images describe`) to check existence: describe
-          # can't tell a missing tag from an API error, so we could accidentally
-          # overwrite an existing RC tag. `tags list` only fails on a real error.
-          if ! RC_TAGS="$(gcloud artifacts docker tags list "$IMAGE" \
+          # Use `tags list` here instead of `images describe` for the existence check:
+          # - `describe` cannot tell between a missing tag and an API failure
+          # - `list` only exits non-zero for a real failure
+          if ! ALL_TAGS="$(gcloud artifacts docker tags list "$IMAGE" \
               --format='value(tag)')"; then
             echo "::error::Failed to list tags for ${IMAGE}; aborting rather than risk moving an existing RC tag."
             exit 1
@@ -138,18 +150,27 @@ jobs:
 
           rc_exists=false
           while IFS= read -r t; do
-            # Docker tags can't contain '/', so basename matches a short name or full path.
+            # Docker tags can't contain '/', so stripping any path prefix is safe
             [[ -n "$t" && "${t##*/}" == "$RC_TAG" ]] && { rc_exists=true; break; }
-          done <<< "$RC_TAGS"
+          done <<< "$ALL_TAGS"
 
-          # Same digest: already tagged, nothing to do. Different digest: refuse
-          # to move an existing RC tag.
           if [[ "$rc_exists" == "true" ]]; then
             RC_DIGEST="$(get_digest "${IMAGE}:${RC_TAG}")"
-            if [[ "$RC_DIGEST" == "$SOURCE_DIGEST" ]]; then
+            if [[ -z "$RC_DIGEST" ]]; then
+              echo "::error::RC tag ${RC_TAG} exists, but its digest could not be resolved."
+              echo "::error::Check GAR access and API availability, then rerun."
+              exit 1
+            elif [[ ! "$RC_DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+              echo "::error::Invalid digest for RC tag ${RC_TAG}: '$RC_DIGEST'"
+              exit 1
+            elif [[ "$RC_DIGEST" == "$SOURCE_DIGEST" ]]; then
               echo "RC tag ${RC_TAG} already points to ${SOURCE_DIGEST}. Nothing to do."
             else
-              echo "::error::RC tag ${RC_TAG} already exists on a different digest (${RC_DIGEST:-unknown}); refusing to move it."
+              # `tags add` would repoint the tag at this image instead. Stage pins to
+              # this tag, so moving it could cause stage to run a different image
+              # without a values-file change. We exit instead of overwriting.
+              echo "::error::RC tag ${RC_TAG} already points to a different image (${RC_DIGEST})."
+              echo "::error::Use a new RC number instead of overwriting this tag."
               exit 1
             fi
           else

--- a/.github/workflows/tag-release-candidate.yml
+++ b/.github/workflows/tag-release-candidate.yml
@@ -1,0 +1,181 @@
+name: Tag Release Candidate in GAR
+
+on:
+  workflow_dispatch:
+    inputs:
+      commit_sha:
+        description: "Full commit SHA on main that the image was built from"
+        required: true
+        type: string
+      rc_number:
+        description: "Release candidate number (the N in vX.Y.Z-rc.N)"
+        required: true
+        type: string
+
+concurrency:
+  group: mlpa-image-promotion
+  cancel-in-progress: false
+
+env:
+  GAR_LOCATION: us
+  GCP_PROJECT_ID: moz-fx-llm-proxy-prod-b0b8
+  GAR_REPOSITORY: llm-proxy-prod
+  GAR_NAME: mlpa
+  GCPV2_GITHUB_WORKLOAD_IDENTITY_PROVIDER: projects/324168772199/locations/global/workloadIdentityPools/github-actions/providers/github-actions
+
+jobs:
+  tag-rc:
+    runs-on: ubuntu-latest
+    environment: build
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Validate inputs
+        env:
+          COMMIT_SHA: ${{ inputs.commit_sha }}
+          RC_NUMBER: ${{ inputs.rc_number }}
+        run: |
+          set -euo pipefail
+          if [[ ! "$COMMIT_SHA" =~ ^[0-9a-fA-F]{40}$ ]]; then
+            echo "::error::commit_sha must be a full 40-character hex SHA"
+            exit 1
+          fi
+          if [[ ! "$RC_NUMBER" =~ ^[1-9][0-9]*$ ]]; then
+            echo "::error::rc_number must be a positive integer"
+            exit 1
+          fi
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.commit_sha }}
+          # Full history so the on-main check below can fetch origin/main.
+          # persist-credentials: false is fine while the repo is public (the fetch
+          # needs no auth); a private repo would need a token here instead.
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Verify candidate is on main
+        env:
+          COMMIT_SHA: ${{ inputs.commit_sha }}
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin "+refs/heads/main:refs/remotes/origin/main"
+          if ! git merge-base --is-ancestor "$COMMIT_SHA" origin/main; then
+            echo "::error::Commit $COMMIT_SHA is not an ancestor of main"
+            exit 1
+          fi
+
+      - name: Derive tags and version
+        id: tags
+        env:
+          COMMIT_SHA: ${{ inputs.commit_sha }}
+          RC_NUMBER: ${{ inputs.rc_number }}
+        run: |
+          set -euo pipefail
+
+          # Use the same short SHA the build used to tag the image.
+          SOURCE_TAG="$(git rev-parse --short=10 "$COMMIT_SHA")"
+
+          VERSION="$(python3 -c "import tomllib, pathlib; print(tomllib.loads(pathlib.Path('pyproject.toml').read_text())['project']['version'])")"
+          if [[ ! "$VERSION" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+            echo "::error::project.version '$VERSION' is not a valid X.Y.Z version"
+            exit 1
+          fi
+
+          echo "source_tag=${SOURCE_TAG}" >> "$GITHUB_OUTPUT"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "rc_tag=v${VERSION}-rc.${RC_NUMBER}" >> "$GITHUB_OUTPUT"
+          echo "Source tag: ${SOURCE_TAG}  ->  RC tag: v${VERSION}-rc.${RC_NUMBER}"
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          service_account: artifact-writer@${{ env.GCP_PROJECT_ID }}.iam.gserviceaccount.com
+          workload_identity_provider: ${{ env.GCPV2_GITHUB_WORKLOAD_IDENTITY_PROVIDER }}
+
+      - name: Set up gcloud
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Tag release candidate
+        id: tag
+        env:
+          SOURCE_TAG: ${{ steps.tags.outputs.source_tag }}
+          RC_TAG: ${{ steps.tags.outputs.rc_tag }}
+        run: |
+          set -euo pipefail
+          IMAGE="${GAR_LOCATION}-docker.pkg.dev/${GCP_PROJECT_ID}/${GAR_REPOSITORY}/${GAR_NAME}"
+
+          # Return the image digest for a ref, or empty if it doesn't resolve.
+          get_digest() {
+            gcloud artifacts docker images describe "$1" \
+              --format='value(image_summary.digest)' 2>/dev/null || true
+          }
+
+          # Source image must exist — stop if we can't resolve its digest.
+          SOURCE_DIGEST="$(get_digest "${IMAGE}:${SOURCE_TAG}")"
+          if [[ -z "$SOURCE_DIGEST" ]]; then
+            echo "::error::Source image ${IMAGE}:${SOURCE_TAG} not found. Was this commit built on main?"
+            exit 1
+          fi
+          if [[ ! "$SOURCE_DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            echo "::error::Invalid source digest: '$SOURCE_DIGEST'"
+            exit 1
+          fi
+          echo "Source: ${IMAGE}:${SOURCE_TAG} -> ${SOURCE_DIGEST}"
+
+          # Use `tags list` (not `images describe`) to check existence: describe
+          # can't tell a missing tag from an API error, so we could accidentally
+          # overwrite an existing RC tag. `tags list` only fails on a real error.
+          if ! RC_TAGS="$(gcloud artifacts docker tags list "$IMAGE" \
+              --format='value(tag)')"; then
+            echo "::error::Failed to list tags for ${IMAGE}; aborting rather than risk moving an existing RC tag."
+            exit 1
+          fi
+
+          rc_exists=false
+          while IFS= read -r t; do
+            # Docker tags can't contain '/', so basename matches a short name or full path.
+            [[ -n "$t" && "${t##*/}" == "$RC_TAG" ]] && { rc_exists=true; break; }
+          done <<< "$RC_TAGS"
+
+          # Same digest: already tagged, nothing to do. Different digest: refuse
+          # to move an existing RC tag.
+          if [[ "$rc_exists" == "true" ]]; then
+            RC_DIGEST="$(get_digest "${IMAGE}:${RC_TAG}")"
+            if [[ "$RC_DIGEST" == "$SOURCE_DIGEST" ]]; then
+              echo "RC tag ${RC_TAG} already points to ${SOURCE_DIGEST}. Nothing to do."
+            else
+              echo "::error::RC tag ${RC_TAG} already exists on a different digest (${RC_DIGEST:-unknown}); refusing to move it."
+              exit 1
+            fi
+          else
+            gcloud artifacts docker tags add "${IMAGE}@${SOURCE_DIGEST}" "${IMAGE}:${RC_TAG}"
+            echo "Tagged ${IMAGE}@${SOURCE_DIGEST} as ${IMAGE}:${RC_TAG}"
+          fi
+
+          echo "digest=${SOURCE_DIGEST}" >> "$GITHUB_OUTPUT"
+
+      - name: Summary
+        env:
+          COMMIT_SHA: ${{ inputs.commit_sha }}
+          SOURCE_TAG: ${{ steps.tags.outputs.source_tag }}
+          VERSION: ${{ steps.tags.outputs.version }}
+          RC_TAG: ${{ steps.tags.outputs.rc_tag }}
+          DIGEST: ${{ steps.tag.outputs.digest }}
+        run: |
+          set -euo pipefail
+          cat >> "$GITHUB_STEP_SUMMARY" << EOF
+          ## RC Tag
+
+          | Field | Value |
+          |---|---|
+          | Commit | \`${COMMIT_SHA}\` |
+          | Source tag | \`${SOURCE_TAG}\` |
+          | Version | \`${VERSION}\` |
+          | RC tag | \`${RC_TAG}\` |
+          | Digest | \`${DIGEST}\` |
+          EOF

--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,8 @@ setup: node-setup
 	@echo "✅ Setup complete! To activate your environment, run:"
 	@echo "   source $(VENV)/bin/activate"
 
-# Ensure the Node version `make docs` needs (.nvmrc). Best-effort and non-fatal:
-# Redoc emits Node-specific CSS hashes, so docs must be built on this version.
+# Ensure the Node version `make docs` needs (.nvmrc). Best-effort and non-fatal.
+# `styled-components` (pinned in `docs`) generates the CSS hashes rather than Node.
 node-setup:
 	@want=$$(cat .nvmrc); \
 	if command -v node >/dev/null 2>&1 && [ "$$(node -v | sed 's/v\([0-9]*\).*/\1/')" = "$$want" ]; then \
@@ -53,12 +53,11 @@ docs:
 	want=$$(cat .nvmrc); have=$$(node -v | sed 's/v\([0-9]*\).*/\1/'); \
 	if [ "$$have" != "$$want" ]; then \
 		echo "make docs needs Node $$want (see .nvmrc); found Node $$have."; \
-		echo "Redoc emits Node-specific CSS hashes, so a mismatch fails the CI docs check."; \
 		echo "Switch with: nvm use  (or e.g. brew install node@$$want)"; \
 		exit 1; \
 	fi; \
 	uv run python -c "from mlpa.run import app; import json; json.dump(app.openapi(), open('openapi.json', 'w'), indent=2)" && \
-	npx --yes @redocly/cli@2.5.0 build-docs openapi.json -o docs/index.html && \
+	npx --yes -p @redocly/cli@2.5.0 -p styled-components@6.4.3 redocly build-docs openapi.json -o docs/index.html && \
 	rm -f openapi.json
 
 # NOTE: for local development only


### PR DESCRIPTION
## What's New

- Adds `.github/workflows/tag-release-candidate.yml`, a `workflow_dispatch` workflow that tags an existing main-build image in GAR as a release candidate (`vX.Y.Z-rc.N`)
- Tags the existing digest directly (no pull, no rebuild) via `gcloud artifacts docker tags add`
- Inputs: a full commit SHA and an RC number
- Validates the commit is on `main`, reads the version from `pyproject.toml`, and derives the RC tag
- Safe to re-run: re-tagging the same digest is a no-op, and it refuses to move an existing RC tag to a different digest. Fails closed if the source image is missing or the registry lookup errors.
- Keyless auth via the existing `artifact-writer` Workload Identity setup, no new secrets or permissions

## Context

This PR is part of [AIPLAT-911](https://mozilla-hub.atlassian.net/browse/AIPLAT-911) (per-environment image tiers). It establishes the stage tier for MLPA: dev runs `latest`, stage will pin to an RC tag, and prod stays on stable semver.

The workflow promotes a selected main-build image to `vX.Y.Z-rc.N` by adding a tag to the existing digest in GAR. It does not rebuild, pull, or push any image. A separate follow-up PR will add a stable promotion workflow triggered on GitHub release.

Every step after the build tags the same digest.
```mermaid
flowchart LR
    A[merge to main] --> B["build<br/>(short-SHA tag)"]
    B --> C["this PR<br/>adds vX.Y.Z-rc.N"]
    C --> D["validate RC on stage<br/>(manual)"]
    D --> E["create GitHub release<br/>(manual)"]
    E --> F["follow-up PR<br/>adds vX.Y.Z"]

    style C fill:#e8f4f8
```

## Testing

Not yet run. A `workflow_dispatch` workflow only appears in the Actions "Run workflow" UI after it lands on the default branch, so it can't be triggered from the PR branch. Will validate post-merge by promoting a known `main` build (latest) and confirming the RC tag lands on the expected digest.

## How to use

From the Actions tab, select "Tag Release Candidate in GAR", click "Run workflow" on `main`, and provide:
- The full commit SHA of a main-branch build
- The RC number (1, 2, 3, ...)

The workflow produces a job summary table with the commit, source tag, version, RC tag, and digest.

## Related

- [AIPLAT-911](https://mozilla-hub.atlassian.net/browse/AIPLAT-911)