### PR TITLE
perf: Postgres storage tuning for app_attest hot tables

### DIFF
--- a/alembic/versions/b3ea148a6d0b_tune_autovacuum_and_fillfactor_on_app_.py
+++ b/alembic/versions/b3ea148a6d0b_tune_autovacuum_and_fillfactor_on_app_.py
@@ -1,0 +1,71 @@
+"""Postgres storage tuning for app_attest hot tables
+
+Revision ID: b3ea148a6d0b
+Revises: 919c4d382c42
+Create Date: 2026-07-27
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "b3ea148a6d0b"
+down_revision = "919c4d382c42"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        ALTER TABLE challenges SET (
+            autovacuum_vacuum_scale_factor = 0.05,
+            autovacuum_vacuum_cost_limit = 2000
+        )
+        """
+    )
+    op.execute(
+        """
+        ALTER TABLE public_keys SET (
+            fillfactor = 85,
+            autovacuum_vacuum_scale_factor = 0.05
+        )
+        """
+    )
+    op.execute(
+        """
+        ALTER TABLE mlpa_user_capacity SET (
+            fillfactor = 70,
+            autovacuum_vacuum_scale_factor = 0.0,
+            autovacuum_vacuum_threshold = 1000
+        )
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        """
+        ALTER TABLE mlpa_user_capacity RESET (
+            fillfactor,
+            autovacuum_vacuum_scale_factor,
+            autovacuum_vacuum_threshold
+        )
+        """
+    )
+    op.execute(
+        """
+        ALTER TABLE public_keys RESET (
+            fillfactor,
+            autovacuum_vacuum_scale_factor
+        )
+        """
+    )
+    op.execute(
+        """
+        ALTER TABLE challenges RESET (
+            autovacuum_vacuum_scale_factor,
+            autovacuum_vacuum_cost_limit
+        )
+        """
+    )


### PR DESCRIPTION
## Description

This PR reduces bloat on the three high-churn tables in the app_attest database by tuning autovacuum, hot updates, and fillfactor on those tables. Utilizing a hand-written Alembic migration. The changes are storage-param-only `ALTER TABLE ... SET (...)` statements. Updating catalog settings, run fast, and do not rewrite the table. Please note the migration can be reverted  to the previous state without impacting existing behavior.

Tables:
- **challenges**: lower `autovacuum_vacuum_scale_factor` 0.2 -> 0.05 and raise `autovacuum_vacuum_cost_limit` to 2000, so autovacuum reclaims the dead rows from the per-request insert+delete churn sooner and faster.
- **public_keys**: set `fillfactor=85` and `scale_factor=0.05` so the per-request counter/updated_at updates stay hot, avoiding primary-key index writes and index bloat.
- **mlpa_user_capacity**: set `fillfactor=70` and raise the autovacuum threshold to 1000 (`scale_factor=0`) so the single hot row's updates stay hot on one page and we stop over-vacuuming a one-row table

## QA Path

Validated on a local database. First confirmed no change in existing behavior: the app_attest unit/integration tests pass, and the attest→assert flow is unchanged.

The migration itself was verified up and down: `reloptions` on the three tables are NULL before, show the tuned values after `upgrade`, and return to NULL after `downgrade`.

Behavior of each table was then confirmed using the `pageinspect` and `pgstattuple` extensions via local scripts, toggling the migration (`downgrade 919c4d382c42` / `upgrade head`)between a "before" and "after" run.

### Challenges
Seeds 900 rows, then updates 150 rows to create 150 dead tuples. Effective trigger = `50 + scale_factor × reltuples`:

| | trigger (reltuples=900) | 150 dead → |
|---|---|---|
| BEFORE (0.2) | 230 | autovacuum did **not** fire |
| AFTER (0.05) | 95  | autovacuum **fired** |

Additionally simulated performance by inserting 3000 rows in challenges, then each round insert 30 new challenges and delete 30 olds ones. Resulting in 450 dead tuples per minute. Before tuning dead rows climb to ~870 and autovacuum fires every ~2 cycles. After the tuning the number of rows climb to ~450 and autovacuum rows about every cycle.

<img width="640" height="395" alt="image" src="https://github.com/user-attachments/assets/3fbc174e-c1e3-4bd1-9388-bf4752050cbc" />


### Public Keys
150 keys with 5000 counter-bump updates. Hot-update ratio measured from `pg_stat_user_tables`, and hot chains confirmed via `pageinspect`:

| | fillfactor | HOT ratio |
|---|---|---|
| BEFORE | 100 | ~3.8% |
| AFTER  | 85  | ~21.6% |

### MLPA User Capacity
500 updates against the single `id=1` row; ~99% HOT, confined to one page.

| | autovacuum threshold | 500 dead → |
|---|---|---|
| BEFORE | ~50   | autovacuum **fired** |
| AFTER  | 1000  | autovacuum did **not** fire |

## Related Tickets & Documents
[AIPLAT-1141](https://mozilla-hub.atlassian.net/browse/AIPLAT-1141?atlOrigin=eyJpIjoiZmJmZjIwMWJmN2Y5NGJiMWFhNDFmYTUzNTE2OTY4ZjQiLCJwIjoiaiJ9)
