### PR TITLE
fix: pin uv version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN chmod +x /app/scripts/migrate-app-attest-database.sh
 RUN chmod +x /app/scripts/migrate-litellm-database.sh
 
 # Install dependencies
-RUN pip install --no-cache-dir uv
+RUN pip install --no-cache-dir uv==0.10.8
 RUN apt-get update && apt-get install -y git
 RUN uv pip install --system --editable .
 


### PR DESCRIPTION
## What's New

- Pins `uv` to `0.10.8` in the Dockerfile, matching what every workflow in the repo already uses

## Context

The Dockerfile ran `pip install --no-cache-dir uv` with no version pin, so it picked up whatever was latest on PyPI. `uv 0.12.0` [released](https://github.com/astral-sh/uv/releases#release-0.12.0) and [the build started failing](https://github.com/Firefox-AI/MLPA/actions/runs/30458540950/job/90598312978).

```
error: Required uv version `>=0.10, <0.12` does not match the running version `0.12.0`
```

`pyproject.toml` sets `required-version = ">=0.10,<0.12"`, so uv refuses to run. This would break any build on main right now, not just a specific commit.

Every workflow (`linters_and_tests.yml`, `auto-bump-version.yml`, `post-deploy-smoke.yml`) already pins `uv==0.10.8`. The Dockerfile was the only unpinned install, so this brings it in line and keeps CI and the image on the same version.

## Related

- [AIPLAT-1169](https://mozilla-hub.atlassian.net/browse/AIPLAT-1169): uv is pinned in six places now, so bumping it means touching all of them. That ticket covers establishing canonical versioning.