### PR TITLE
feat: track firefox client version from user agent

### DIFF
--- a/src/mlpa/core/config.py
+++ b/src/mlpa/core/config.py
@@ -272,6 +272,10 @@ class Env(BaseSettings):
             | {""}
         )
 
+    @cached_property
+    def valid_major_fx_versions_set(self) -> set[str]:
+        return {str(n) for n in range(100, 200)}
+
     def service_type_requires_purpose(self, service_type: str) -> bool:
         """True if the purpose header is mandatory for this service type."""
         return len(self.valid_purposes_for_service_type(service_type)) > 0

--- a/src/mlpa/core/middleware/instrumentation.py
+++ b/src/mlpa/core/middleware/instrumentation.py
@@ -1,4 +1,3 @@
-import re
 import time
 
 from fastapi import Request
@@ -10,9 +9,8 @@ from mlpa.core.utils import (
     clamp_purpose,
     clamp_request_method,
     clamp_service_type,
+    parse_firefox_major_version_from_user_agent,
 )
-
-FX_USER_AGENT_RE = r".*?Firefox/(\d+\.\d+)"
 
 
 async def instrument_requests_middleware(request: Request, call_next):
@@ -39,21 +37,7 @@ async def instrument_requests_middleware(request: Request, call_next):
             service_type = request.headers.get("service-type", "")
             purpose = request.headers.get("purpose", "")
             user_agent = request.headers.get("user-agent", "")
-            major_fx_version = ""
-            try:
-                if user_agent:
-                    fx_user_agent_match = re.match(FX_USER_AGENT_RE, user_agent)
-                    fx_version = (
-                        fx_user_agent_match.group(1) if fx_user_agent_match else ""
-                    )
-                    (major_fx_version, minor_fx_version) = (
-                        fx_version.split(".") if fx_version else ("", "")
-                    )
-            except Exception as e:
-                logger.error(
-                    f"Failed to parse firefox version from user-agent: {user_agent} {e}"
-                )
-                major_fx_version = "unknown"
+            major_fx_version = parse_firefox_major_version_from_user_agent(user_agent)
             metrics.request_latency.labels(method=method, endpoint=endpoint).observe(
                 time.perf_counter() - start_time
             )

--- a/src/mlpa/core/middleware/instrumentation.py
+++ b/src/mlpa/core/middleware/instrumentation.py
@@ -1,10 +1,18 @@
+import re
 import time
 
 from fastapi import Request
 
 from mlpa.core.logger import logger
 from mlpa.core.prometheus_metrics import metrics
-from mlpa.core.utils import clamp_purpose, clamp_request_method, clamp_service_type
+from mlpa.core.utils import (
+    clamp_major_fx_version,
+    clamp_purpose,
+    clamp_request_method,
+    clamp_service_type,
+)
+
+FX_USER_AGENT_RE = r".*?Firefox/(\d+\.\d+)"
 
 
 async def instrument_requests_middleware(request: Request, call_next):
@@ -30,7 +38,22 @@ async def instrument_requests_middleware(request: Request, call_next):
             method = clamp_request_method(request.method)
             service_type = request.headers.get("service-type", "")
             purpose = request.headers.get("purpose", "")
-
+            user_agent = request.headers.get("user-agent", "")
+            major_fx_version = ""
+            try:
+                if user_agent:
+                    fx_user_agent_match = re.match(FX_USER_AGENT_RE, user_agent)
+                    fx_version = (
+                        fx_user_agent_match.group(1) if fx_user_agent_match else ""
+                    )
+                    (major_fx_version, minor_fx_version) = (
+                        fx_version.split(".") if fx_version else ("", "")
+                    )
+            except Exception as e:
+                logger.error(
+                    f"Failed to parse firefox version from user-agent: {user_agent} {e}"
+                )
+                major_fx_version = "unknown"
             metrics.request_latency.labels(method=method, endpoint=endpoint).observe(
                 time.perf_counter() - start_time
             )
@@ -39,6 +62,7 @@ async def instrument_requests_middleware(request: Request, call_next):
                 endpoint=endpoint,
                 service_type=clamp_service_type(service_type),
                 purpose=clamp_purpose(purpose),
+                major_fx_version=clamp_major_fx_version(major_fx_version),
             ).inc()
             metrics.response_status_codes.labels(status_code=response.status_code).inc()
             return response

--- a/src/mlpa/core/prometheus_metrics.py
+++ b/src/mlpa/core/prometheus_metrics.py
@@ -209,7 +209,7 @@ def build_metrics(registry: CollectorRegistry = REGISTRY) -> PrometheusMetrics:
         requests_total=Counter(
             "mlpa_requests_total",
             "Total number of requests handled by the proxy.",
-            ["method", "endpoint", "service_type", "purpose"],
+            ["method", "endpoint", "service_type", "purpose", "major_fx_version"],
             registry=registry,
         ),
         requests_by_country_total=Counter(

--- a/src/mlpa/core/utils.py
+++ b/src/mlpa/core/utils.py
@@ -82,6 +82,11 @@ def clamp_purpose(raw: str) -> str:
     return raw if raw == "" or raw in env.valid_purposes_set else "other"
 
 
+def clamp_major_fx_version(raw: str) -> str:
+    """Bound firefox version to known values, else "unknown"."""
+    return raw if raw == "" or raw in env.valid_major_fx_versions_set else "unknown"
+
+
 def clamp_country(raw: str | None) -> str:
     """Bound an edge-stamped client country to a known country code, else "unknown".
 

--- a/src/mlpa/core/utils.py
+++ b/src/mlpa/core/utils.py
@@ -34,6 +34,7 @@ KNOWN_HTTP_METHODS = frozenset(
         "PUT",
     }
 )
+FX_USER_AGENT_RE = r".*?Firefox/(\d+\.\d+)"
 
 
 def clamp_model(model: str) -> str:
@@ -424,3 +425,15 @@ def issue_mlpa_access_token(user_id: str) -> str:
         env.MLPA_ACCESS_TOKEN_SECRET,
         algorithm="HS256",
     )
+
+
+def parse_firefox_major_version_from_user_agent(user_agent: str) -> str:
+    major_version = ""
+    try:
+        match = re.match(FX_USER_AGENT_RE, user_agent)
+        if match:
+            major_version = match.group(1).split(".")[0]
+    except Exception as e:
+        logger.error(f"Failed to parse user agent: {user_agent} {e}")
+        major_version = "unknown"
+    return major_version

--- a/src/tests/unit/test_config.py
+++ b/src/tests/unit/test_config.py
@@ -66,6 +66,14 @@ def test_valid_service_types_includes_memories():
     assert isinstance(service_types, list)
 
 
+def test_valid_major_fx_versions_set_uses_string_range():
+    env = Env()
+
+    assert "155" in env.valid_major_fx_versions_set
+    assert 155 not in env.valid_major_fx_versions_set
+    assert env.valid_major_fx_versions_set == {str(n) for n in range(100, 200)}
+
+
 def test_user_feature_budget_dev_service_types_default_values():
     """Test that ai-dev, memories-dev, and mochi-dev have correct default values."""
     env = Env()

--- a/src/tests/unit/test_middleware_order.py
+++ b/src/tests/unit/test_middleware_order.py
@@ -280,6 +280,9 @@ def test_set_json_content_type_does_not_change_other_routes():
 
 def test_instrumentation_tracks_valid_firefox_major_version(metrics_spy):
     from mlpa.core.middleware.instrumentation import instrument_requests_middleware
+    from mlpa.core.utils import parse_firefox_major_version_from_user_agent
+
+    user_agent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:155.0) Gecko/20100101 Firefox/155.0"
 
     app = FastAPI()
     app.middleware("http")(instrument_requests_middleware)
@@ -294,7 +297,7 @@ def test_instrumentation_tracks_valid_firefox_major_version(metrics_spy):
         headers={
             "service-type": "ai",
             "purpose": "chat",
-            "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:155.0) Gecko/20100101 Firefox/155.0",
+            "user-agent": user_agent,
         },
     )
 
@@ -306,7 +309,7 @@ def test_instrumentation_tracks_valid_firefox_major_version(metrics_spy):
             endpoint="/test",
             service_type="ai",
             purpose="chat",
-            major_fx_version="155",
+            major_fx_version=parse_firefox_major_version_from_user_agent(user_agent),
         )
         == 1
     )
@@ -314,6 +317,9 @@ def test_instrumentation_tracks_valid_firefox_major_version(metrics_spy):
 
 def test_instrumentation_tracks_invalid_firefox_major_version(metrics_spy):
     from mlpa.core.middleware.instrumentation import instrument_requests_middleware
+    from mlpa.core.utils import parse_firefox_major_version_from_user_agent
+
+    user_agent = "bruno-runtime/3.4.2"
 
     app = FastAPI()
     app.middleware("http")(instrument_requests_middleware)
@@ -328,7 +334,7 @@ def test_instrumentation_tracks_invalid_firefox_major_version(metrics_spy):
         headers={
             "service-type": "ai",
             "purpose": "chat",
-            "user-agent": "bruno-runtime/3.4.2",
+            "user-agent": user_agent,
         },
     )
 
@@ -340,7 +346,7 @@ def test_instrumentation_tracks_invalid_firefox_major_version(metrics_spy):
             endpoint="/test",
             service_type="ai",
             purpose="chat",
-            major_fx_version="",
+            major_fx_version=parse_firefox_major_version_from_user_agent(user_agent),
         )
         == 1
     )

--- a/src/tests/unit/test_middleware_order.py
+++ b/src/tests/unit/test_middleware_order.py
@@ -85,6 +85,7 @@ def test_instrumentation_bounds_pre_auth_request_labels(metrics_spy):
             endpoint="/test",
             service_type="other",
             purpose="other",
+            major_fx_version="",
         )
         == 1
     )
@@ -95,6 +96,7 @@ def test_instrumentation_bounds_pre_auth_request_labels(metrics_spy):
             endpoint="/test",
             service_type="not-real-service-type",
             purpose="not-real-purpose",
+            major_fx_version="",
         )
         == 0
     )
@@ -127,6 +129,7 @@ def test_instrumentation_keeps_known_pre_auth_request_labels(metrics_spy):
             endpoint="/test",
             service_type="ai",
             purpose="chat",
+            major_fx_version="",
         )
         == 1
     )
@@ -153,6 +156,7 @@ def test_instrumentation_keeps_empty_purpose_as_bounded_label(metrics_spy):
             endpoint="/test",
             service_type="s2s",
             purpose="",
+            major_fx_version="",
         )
         == 1
     )
@@ -186,6 +190,7 @@ def test_instrumentation_buckets_unknown_methods(metrics_spy):
             endpoint="/test",
             service_type="ai",
             purpose="chat",
+            major_fx_version="",
         )
         == 1
     )
@@ -196,6 +201,7 @@ def test_instrumentation_buckets_unknown_methods(metrics_spy):
             endpoint="/test",
             service_type="ai",
             purpose="chat",
+            major_fx_version="",
         )
         == 0
     )
@@ -270,3 +276,71 @@ def test_set_json_content_type_does_not_change_other_routes():
     assert response.status_code == 200
     assert response.json() == {"content_type": "application/x-www-form-urlencoded"}
     assert seen_content_types == ["application/x-www-form-urlencoded"]
+
+
+def test_instrumentation_tracks_valid_firefox_major_version(metrics_spy):
+    from mlpa.core.middleware.instrumentation import instrument_requests_middleware
+
+    app = FastAPI()
+    app.middleware("http")(instrument_requests_middleware)
+
+    @app.get("/test")
+    async def test_endpoint():
+        return {"status": "ok"}
+
+    client = TestClient(app)
+    response = client.get(
+        "/test",
+        headers={
+            "service-type": "ai",
+            "purpose": "chat",
+            "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:155.0) Gecko/20100101 Firefox/155.0",
+        },
+    )
+
+    assert response.status_code == 200
+    assert (
+        metrics_spy.value(
+            "requests_total",
+            method="GET",
+            endpoint="/test",
+            service_type="ai",
+            purpose="chat",
+            major_fx_version="155",
+        )
+        == 1
+    )
+
+
+def test_instrumentation_tracks_invalid_firefox_major_version(metrics_spy):
+    from mlpa.core.middleware.instrumentation import instrument_requests_middleware
+
+    app = FastAPI()
+    app.middleware("http")(instrument_requests_middleware)
+
+    @app.get("/test")
+    async def test_endpoint():
+        return {"status": "ok"}
+
+    client = TestClient(app)
+    response = client.get(
+        "/test",
+        headers={
+            "service-type": "ai",
+            "purpose": "chat",
+            "user-agent": "bruno-runtime/3.4.2",
+        },
+    )
+
+    assert response.status_code == 200
+    assert (
+        metrics_spy.value(
+            "requests_total",
+            method="GET",
+            endpoint="/test",
+            service_type="ai",
+            purpose="chat",
+            major_fx_version="",
+        )
+        == 1
+    )

--- a/src/tests/unit/test_utils.py
+++ b/src/tests/unit/test_utils.py
@@ -16,6 +16,7 @@ from mlpa.core.utils import (
     is_plausible_integrity_token,
     is_rate_limit_error,
     is_valid_model_name,
+    parse_firefox_major_version_from_user_agent,
 )
 
 # Sourced from env.valid_model_labels (not hand-copied) so a future model name
@@ -70,6 +71,22 @@ def test_is_valid_model_name_accepts_slash_and_underscore_namespaced_models(mode
 
 def test_is_valid_model_name_accepts_max_length():
     assert is_valid_model_name("a" * 64) is True
+
+
+@pytest.mark.parametrize(
+    ("user_agent", "expected"),
+    [
+        (
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:155.0) Gecko/20100101 Firefox/155.0",
+            "155",
+        ),
+        ("Mozilla/5.0 Firefox/100.12", "100"),
+        ("bruno-runtime/3.4.2", ""),
+        ("", ""),
+    ],
+)
+def test_parse_firefox_major_version_from_user_agent(user_agent, expected):
+    assert parse_firefox_major_version_from_user_agent(user_agent) == expected
 
 
 @pytest.mark.parametrize("key_id_b64", ["dGVzdC1rZXktaWQ=", "A" * 44, "a+b/c==", "x"])


### PR DESCRIPTION
## What's new

- Add tracking of major firefox version based off `user-agent` header
- Parses major version with regex, defaulting to `""` or `"unknown"` if bad value
- Whitelists firefox version to 100-200, we can pull in the few latest versions from https://product-details.mozilla.org/1.0/firefox_history_stability_releases.json but that adds a dependency, so we're hard coding it for now
https://mozilla-hub.atlassian.net/browse/AIPLAT-1215