### PR TITLE
feat(country-metrics): AIPLAT-1266 per-country metrics

### DIFF
--- a/docs/prometheus-cardinality.md
+++ b/docs/prometheus-cardinality.md
@@ -1,0 +1,177 @@
+# Prometheus metric cardinality: how to check headroom before adding a label
+
+Every new label on a metric multiplies its series count. Get this wrong and a
+"small" Grafana filter either blows up storage/query cost or silently gets
+dropped by a cardinality limit. This is the checklist to run through before
+adding a label to an existing MLPA metric. Written up after
+[AIPLAT-1266](https://mozilla-hub.atlassian.net/browse/AIPLAT-1266), adding a
+country/region filter to Grafana, needed exactly this analysis.
+
+## The formula
+
+```
+series = (product of each label's distinct values) × (bucket count, for Histograms only)
+```
+
+Counters and Gauges: one series per label combination. Histograms: one
+series per label combination *per bucket* (`_bucket` samples), plus `_count`
+and `_sum`. A histogram with 12 buckets costs about 12x what a counter with
+the same labels costs.
+
+Multiplying declared label sets together gives you a ceiling, not reality.
+Labels usually correlate. MLPA's `purpose` header is only non-empty for 5 of
+13 service types, so `service_type × purpose` never hits its full cross
+product. Don't call something "too expensive" or "safe" until you've checked
+the real numbers.
+
+## How to check current headroom
+
+MLPA metrics live in Google Managed Prometheus (GMP), queryable via its
+PromQL-compatible API against `moz-fx-dataservices-high-{prod,nonpr}`. Auth
+with local `gcloud` ADC (`gcloud auth login` if the token refresh fails), then
+call the query API directly:
+```bash
+PROJECT="moz-fx-dataservices-high-prod"
+TOKEN=$(gcloud auth print-access-token)
+curl -s -G "https://monitoring.googleapis.com/v1/projects/${PROJECT}/location/global/prometheus/api/v1/query" \
+  -H "Authorization: Bearer ${TOKEN}" \
+  --data-urlencode 'query=<promql query>'
+```
+
+First, list a metric family's samples. GMP doesn't support `=~` on
+`__name__`, so use its metadata endpoint filtered by prefix instead of a
+regex query:
+```bash
+curl -s -G "https://monitoring.googleapis.com/v1/projects/${PROJECT}/location/global/prometheus/api/v1/label/__name__/values" \
+  -H "Authorization: Bearer ${TOKEN}" \
+  --data-urlencode 'match[]=mlpa_chat_completion_latency_seconds'
+```
+
+Then count current active series for one metric:
+```
+query=count(mlpa_chat_completion_latency_seconds_bucket)
+```
+
+Count distinct label combinations too. That's the number that matters before
+you multiply by buckets:
+```
+query=count(mlpa_chat_completion_latency_seconds_count)
+```
+
+And check how many distinct values a candidate label would actually take in
+production, using a metric that already carries it:
+```
+query=count(count by (client_country) (mlpa_requests_by_country_total))
+```
+
+That last one is the step people skip. A label that looks bounded in theory,
+like an ISO country code, can still be wide open in practice. See below.
+
+## Worked example: MLPA in prod
+
+Snapshot pulled from prod while writing this doc. Numbers drift, rerun the
+queries above for current ones.
+
+| Metric | Distinct label combos | Buckets | Total series |
+|---|---|---|---|
+| `mlpa_chat_completion_latency_seconds` (result×model×service_type×purpose) | 128 | 11 | 1,408 |
+| `mlpa_chat_completion_ttft_seconds` (model only) | 24 | 9 | 216 |
+| `mlpa_chat_availability_total` (outcome×reason×model×service_type×purpose) | 187 | n/a | 187 |
+| `mlpa_requests_by_country_total` (service_type×model×client_country) | 2,244 | n/a | 2,244 |
+
+Two things stood out when pulling these. 211 distinct countries have shown up
+in `client_country` on `requests_by_country_total`, out of the 249 in
+`COUNTRY_CODES`. Country is a wide dimension in real traffic (bots, VPNs,
+travelers), even though the app is officially available in only a handful of
+markets. And only 6 distinct models are actively receiving traffic, out of
+11 configured. Real variety runs lower than the declared label set, but not
+always in the direction you'd guess.
+
+Here's the number that matters for this decision: if `client_country` (full
+ISO, 211 real values) had been added directly to `chat_completion_latency`,
+its 1,408 series today would become roughly 297,000 (128 combos × 211
+countries × 11 buckets). That's measured off real traffic, not a worst-case
+guess, and it's why AIPLAT-1266 didn't go that route.
+
+## Add a label to an existing metric, or make a new one?
+
+Start with the metric type. Counters absorb a new bounded label fairly
+cheaply, since there's no bucket multiplier. A histogram multiplies by
+bucket count, so the same label costs `buckets`x more there than on a
+counter with identical cardinality.
+
+Next, check the label's real cardinality (the query above). If it's small,
+roughly 10 or fewer distinct values, and closed, meaning you control it and
+it's not user-generated freetext, adding it directly is fine.
+
+If the label is wide, like full-ISO country, but the dashboard only needs a
+handful of buckets, clamp it to a small hand-maintained set first (see the
+pattern below), and only then decide whether it belongs on an existing
+metric or a new one.
+
+Two separate things push toward a dedicated, deliberately thin metric
+instead of adding the label in place, and either one alone is enough:
+
+- The existing combination count is already large (over roughly 100) and
+  the new label would multiply it by another 5+ values.
+- The dashboard use case doesn't need the new label correlated with the
+  metric's existing labels at all. If it doesn't, drop those labels in the
+  new metric rather than carrying them forward. Dropping an unneeded label
+  usually saves more than the new label costs, even when the existing
+  metric was cheap to begin with. `mlpa_chat_completion_ttft_seconds` has
+  only 24 combos today (`model` alone), comfortably under the first
+  trigger, but a country-only dashboard has no use for per-model TTFT.
+  Adding `client_country` in place would take it from 216 series to 1,080
+  (24 models × 5 countries × 9 buckets). Dropping `model` and building
+  `chat_completion_ttft_by_country` with `client_country` alone costs 45
+  series on top of the untouched original, 261 total, cheaper and simpler
+  to query than the merged version.
+
+Both `mlpa_requests_by_country_total` (AIPLAT-1020) and the three
+AIPLAT-1266 by-country metrics (`chat_completion_latency_by_country`,
+`chat_completion_ttft_by_country`, `chat_availability_by_country`) end up
+carrying only `client_country` plus the bare minimum, not the full label set
+of the metric they resemble, because the dashboard never needed that
+intersection.
+
+Some general Prometheus/GMP thresholds, not MLPA-specific: under about 10k
+active series for a single metric, don't think about it further. Between 10k
+and 100k, take a second look and check the real distinct-combo count before
+adding anything else. And bot, scanner, or freetext input isn't label
+material at all. Clamp it to a known set or drop it. An attacker-controlled
+label value is a spoofing vector as much as a cost problem.
+
+## The bounded-label pattern used in MLPA
+
+Every label that comes from outside MLPA's own config, whether from a header
+or an upstream response, goes through a `clamp_*` function in
+`src/mlpa/core/utils.py` before it touches a metric. The raw value never
+reaches a `.labels()` call directly.
+
+Two flavors of this show up. Some labels are already a known, moderately
+sized enum: `clamp_model`, `clamp_service_type`, `clamp_purpose` all bind to
+`env.valid_*` config, falling back to `"invalid"` or `"other"`. Others are
+externally supplied and technically unbounded, clamped to a purpose-built
+small set instead: `clamp_country` bounds to the full ISO list, falling back
+to `"unknown"`, while `clamp_launch_country` bounds to the 4-country
+dashboard set, falling back to `"other"`. Two different clamps can exist for
+the same raw header when different metrics need different bucketing
+granularity. `clamp_country` backs the wide `requests_by_country_total`
+counter, `clamp_launch_country` backs the thin by-country histograms, and
+both read the same `X-Geo-Country` header.
+
+When adding a new label, write the `clamp_*` function first. Decide its
+bucket set explicitly instead of letting it default to whatever values show
+up, then wire it into a metric.
+
+## Checklist before shipping a new label
+
+1. Which metric type, Counter or Histogram? Histograms cost more.
+2. What's the label's real distinct-value count in production today? Measure
+   it, don't estimate it.
+3. Does it need a `clamp_*` function? Yes, unless the value already comes
+   from a closed, MLPA-controlled enum.
+4. Existing metric or new dedicated metric? Work through the decision above.
+5. After shipping, re-measure with `count(<metric>)` against GMP and confirm
+   it matches what you expected. This catches a clamp that isn't actually
+   bounding what you thought it was.

--- a/src/mlpa/core/auth/authorize.py
+++ b/src/mlpa/core/auth/authorize.py
@@ -124,6 +124,8 @@ async def authorize_chat_request(
     use_qa_certificates: Annotated[bool | None, Header()] = None,
     use_play_integrity: Annotated[bool | None, Header()] = None,
 ) -> AuthorizedChatRequest:
+    client_country = request.headers.get("X-Geo-Country") or ""
+
     # Charset/length check runs before any auth, DB, or LiteLLM work below, so
     # fuzzed/scanner model values are rejected without that cost.
     if not is_valid_model_name(chat_request.model):
@@ -132,6 +134,7 @@ async def authorize_chat_request(
             model=chat_request.model,
             service_type=service_type.value,
             purpose=purpose or "",
+            client_country=client_country,
         )
         raise HTTPException(
             status_code=400,
@@ -160,6 +163,7 @@ async def authorize_chat_request(
             model=chat_request.model,
             service_type=service_type.value,
             purpose=purpose or "",
+            client_country=client_country,
         )
         raise HTTPException(
             status_code=400,
@@ -173,6 +177,7 @@ async def authorize_chat_request(
                 user=user,
                 service_type=service_type.value,
                 purpose=purpose_value,
+                client_country=client_country,
                 **chat_request.model_dump(exclude_unset=True),
             ),
             authorization=authorization,
@@ -202,6 +207,7 @@ async def authorize_chat_request(
             model=chat_request.model,
             service_type=service_type.value,
             purpose=purpose or "",
+            client_country=client_country,
         )
         raise
 
@@ -217,12 +223,14 @@ async def authorize_search_request(
     use_qa_certificates: Annotated[bool | None, Header()] = None,
     use_play_integrity: Annotated[bool | None, Header()] = None,
 ) -> AuthorizedSearchRequest:
+    client_country = request.headers.get("X-Geo-Country") or ""
     return await _authorize_common_request(
         request=request,
         build_authorized_request=lambda user, purpose_value: AuthorizedSearchRequest(
             user=user,
             service_type=service_type.value,
             purpose=purpose_value,
+            client_country=client_country,
             **search_request.model_dump(exclude_unset=True),
         ),
         authorization=authorization,

--- a/src/mlpa/core/auth/authorize.py
+++ b/src/mlpa/core/auth/authorize.py
@@ -18,6 +18,7 @@ from mlpa.core.prometheus_metrics import AvailabilityReason
 from mlpa.core.routers.appattest import app_attest_auth
 from mlpa.core.utils import (
     extract_user_from_play_integrity_jwt,
+    get_client_country,
     is_valid_model_name,
     parse_app_attest_jwt,
 )
@@ -124,7 +125,7 @@ async def authorize_chat_request(
     use_qa_certificates: Annotated[bool | None, Header()] = None,
     use_play_integrity: Annotated[bool | None, Header()] = None,
 ) -> AuthorizedChatRequest:
-    client_country = request.headers.get("X-Geo-Country") or ""
+    client_country = get_client_country(request)
 
     # Charset/length check runs before any auth, DB, or LiteLLM work below, so
     # fuzzed/scanner model values are rejected without that cost.
@@ -223,7 +224,7 @@ async def authorize_search_request(
     use_qa_certificates: Annotated[bool | None, Header()] = None,
     use_play_integrity: Annotated[bool | None, Header()] = None,
 ) -> AuthorizedSearchRequest:
-    client_country = request.headers.get("X-Geo-Country") or ""
+    client_country = get_client_country(request)
     return await _authorize_common_request(
         request=request,
         build_authorized_request=lambda user, purpose_value: AuthorizedSearchRequest(

--- a/src/mlpa/core/classes.py
+++ b/src/mlpa/core/classes.py
@@ -87,18 +87,28 @@ class PlayIntegrityTokenResponse(BaseModel):
     expires_in: int
 
 
-class AuthorizedRequestLogMixin:
+class AuthorizedRequestLogMixin(BaseModel):
     """Shared structured log fields for authorized requests.
 
     Bound into the loguru contextvar via ``logger.contextualize(**log_fields)``
     in the proxy handlers so every log line emitted while serving the request
     (including mid-stream errors) carries them as queryable ``record.extra.*``
     fields, rather than concatenated into the message string.
+
+    A ``BaseModel`` itself (not a plain mixin) so ``ty`` resolves these fields
+    on ``AuthorizedChatRequest``/``AuthorizedSearchRequest`` through multiple
+    inheritance instead of flagging their constructor calls as unknown kwargs.
     """
 
     user: str
     service_type: str
-    purpose: str
+    purpose: str = (
+        ""  # From header; empty for service types without defined purposes (e.g. s2s)
+    )
+    # Raw X-Geo-Country, edge-stamped; clamp at metric time. Read by
+    # requests_by_country_total for both chat and search, and additionally by
+    # the latency/TTFT/availability by-country metrics (AIPLAT-1266) for chat.
+    client_country: str = ""
 
     @property
     def log_fields(self) -> dict[str, str]:
@@ -115,14 +125,7 @@ class AuthorizedRequestLogMixin:
 
 
 class AuthorizedChatRequest(ChatRequest, AuthorizedRequestLogMixin):
-    user: str
-    service_type: str
-    purpose: str = (
-        ""  # From header; empty for service types without defined purposes (e.g. s2s)
-    )
-    # Raw X-Geo-Country, edge-stamped; clamp at metric time. Read by the
-    # by-country chat metrics (AIPLAT-1266).
-    client_country: str = ""
+    pass
 
 
 class SearchRequest(BaseModel):
@@ -131,15 +134,7 @@ class SearchRequest(BaseModel):
 
 
 class AuthorizedSearchRequest(SearchRequest, AuthorizedRequestLogMixin):
-    user: str
-    service_type: str
-    purpose: str = (
-        ""  # From header; empty for service types without defined purposes (e.g. s2s)
-    )
-    # Raw X-Geo-Country, edge-stamped; clamp at metric time. Read by
-    # requests_by_country_total, but not by the latency/TTFT/availability
-    # by-country metrics (AIPLAT-1266), which are chat-only for now.
-    client_country: str = ""
+    pass
 
 
 # Dynamically create ServiceType enum from config

--- a/src/mlpa/core/classes.py
+++ b/src/mlpa/core/classes.py
@@ -120,7 +120,8 @@ class AuthorizedChatRequest(ChatRequest, AuthorizedRequestLogMixin):
     purpose: str = (
         ""  # From header; empty for service types without defined purposes (e.g. s2s)
     )
-    # Raw X-Geo-Country, edge-stamped; clamp at metric time.
+    # Raw X-Geo-Country, edge-stamped; clamp at metric time. Read by the
+    # by-country chat metrics (AIPLAT-1266).
     client_country: str = ""
 
 
@@ -135,9 +136,9 @@ class AuthorizedSearchRequest(SearchRequest, AuthorizedRequestLogMixin):
     purpose: str = (
         ""  # From header; empty for service types without defined purposes (e.g. s2s)
     )
-    # Raw X-Geo-Country, edge-stamped; clamp at metric time. Only chat metrics
-    # (AIPLAT-1266) read this today; search carries it for parity but doesn't
-    # record a by-country metric yet.
+    # Raw X-Geo-Country, edge-stamped; clamp at metric time. Read by
+    # requests_by_country_total, but not by the latency/TTFT/availability
+    # by-country metrics (AIPLAT-1266), which are chat-only for now.
     client_country: str = ""
 
 

--- a/src/mlpa/core/classes.py
+++ b/src/mlpa/core/classes.py
@@ -120,6 +120,8 @@ class AuthorizedChatRequest(ChatRequest, AuthorizedRequestLogMixin):
     purpose: str = (
         ""  # From header; empty for service types without defined purposes (e.g. s2s)
     )
+    # Raw X-Geo-Country, edge-stamped; clamp at metric time.
+    client_country: str = ""
 
 
 class SearchRequest(BaseModel):
@@ -133,6 +135,10 @@ class AuthorizedSearchRequest(SearchRequest, AuthorizedRequestLogMixin):
     purpose: str = (
         ""  # From header; empty for service types without defined purposes (e.g. s2s)
     )
+    # Raw X-Geo-Country, edge-stamped; clamp at metric time. Only chat metrics
+    # (AIPLAT-1266) read this today; search carries it for parity but doesn't
+    # record a by-country metric yet.
+    client_country: str = ""
 
 
 # Dynamically create ServiceType enum from config

--- a/src/mlpa/core/completions.py
+++ b/src/mlpa/core/completions.py
@@ -41,7 +41,7 @@ from mlpa.core.utils import (
 
 def _build_litellm_body(req: AuthorizedChatRequest, *, stream: bool) -> dict:
     body = req.model_dump(
-        exclude={"max_completion_tokens", "service_type", "purpose"},
+        exclude={"max_completion_tokens", "service_type", "purpose", "client_country"},
         exclude_none=True,
     )
     body["max_tokens"] = req.max_completion_tokens
@@ -211,7 +211,7 @@ async def stream_completion(
 
                 if is_first_token:
                     record_ttft(
-                        authorized_chat_request.model,
+                        authorized_chat_request,
                         time.perf_counter() - start_time,
                     )
                     is_first_token = False

--- a/src/mlpa/core/config.py
+++ b/src/mlpa/core/config.py
@@ -1,7 +1,8 @@
 from functools import cached_property
-from typing import Any
+from typing import Annotated, Any
 
-from pydantic_settings import BaseSettings, SettingsConfigDict
+from pydantic import field_validator
+from pydantic_settings import BaseSettings, NoDecode, SettingsConfigDict
 
 
 class Env(BaseSettings):
@@ -23,7 +24,18 @@ class Env(BaseSettings):
     # so the per-country latency/TTFT/availability metrics stay cheap.
     # Everything else clamps to "other" (see utils.clamp_launch_country).
     # Grafana's country/region dropdown reads the same values.
-    MLPA_LAUNCH_COUNTRIES: set[str] = {"US", "CA", "FR", "DE"}
+    # `NoDecode` + the validator below let ops set this as a plain
+    # comma-separated string (e.g. "US,CA,FR,DE,GB"); pydantic-settings'
+    # default complex-type decoding otherwise requires JSON syntax and would
+    # crash the app on startup for the intuitive comma-separated format.
+    MLPA_LAUNCH_COUNTRIES: Annotated[set[str], NoDecode] = {"US", "CA", "FR", "DE"}
+
+    @field_validator("MLPA_LAUNCH_COUNTRIES", mode="before")
+    @classmethod
+    def _parse_launch_countries(cls, raw: str | set[str]) -> set[str]:
+        if isinstance(raw, str):
+            return {code.strip() for code in raw.split(",") if code.strip()}
+        return raw
 
     # Purpose header enforcement/backwards-compatibility:
     # when false (default), the `purpose` header is optional for all service types.

--- a/src/mlpa/core/config.py
+++ b/src/mlpa/core/config.py
@@ -18,6 +18,13 @@ class Env(BaseSettings):
     MLPA_CAPPED_SERVICE_TYPES: set[str] = {"ai", "memories"}
     MLPA_ADMISSION_LOCK_TIMEOUT_MS: int = 5000
 
+    # Countries with their own Grafana breakout (AIPLAT-1266). Deliberately a
+    # small set, distinct from the full ISO country_codes.COUNTRY_CODES list,
+    # so the per-country latency/TTFT/availability metrics stay cheap.
+    # Everything else clamps to "other" (see utils.clamp_launch_country).
+    # Grafana's country/region dropdown reads the same values.
+    MLPA_LAUNCH_COUNTRIES: set[str] = {"US", "CA", "FR", "DE"}
+
     # Purpose header enforcement/backwards-compatibility:
     # when false (default), the `purpose` header is optional for all service types.
     # when true, the `purpose` header becomes mandatory for service types that

--- a/src/mlpa/core/country_codes.py
+++ b/src/mlpa/core/country_codes.py
@@ -1,5 +1,9 @@
 """Bounded country-code labels for Prometheus metrics."""
 
+# NOTE: the small, hand-maintained launch-market set used to bucket
+# per-country metrics (AIPLAT-1266) lives in config.py as
+# `env.MLPA_LAUNCH_COUNTRIES` (overridable without a deploy), not here.
+
 # ISO 3166-1 alpha-2 country codes.
 COUNTRY_CODES = frozenset(
     """

--- a/src/mlpa/core/metrics.py
+++ b/src/mlpa/core/metrics.py
@@ -16,6 +16,7 @@ from mlpa.core.prometheus_metrics import (
 )
 from mlpa.core.utils import (
     clamp_country,
+    clamp_launch_country,
     clamp_model,
     clamp_purpose,
     clamp_service_type,
@@ -72,13 +73,18 @@ def record_chat_availability_for(
     model: str,
     service_type: str,
     purpose: str,
+    client_country: str = "",  # "" (not yet authorized) clamps to "other" below
 ) -> None:
+    outcome = availability_outcome_for(reason)
     metrics.chat_availability.labels(
-        outcome=availability_outcome_for(reason),
+        outcome=outcome,
         reason=reason,
         model=clamp_model(model),
         service_type=clamp_service_type(service_type),
         purpose=clamp_purpose(purpose),
+    ).inc()
+    metrics.chat_availability_by_country.labels(
+        outcome=outcome, client_country=clamp_launch_country(client_country)
     ).inc()
 
 
@@ -90,6 +96,7 @@ def record_chat_availability(
         model=req.model,
         service_type=req.service_type,
         purpose=req.purpose,
+        client_country=req.client_country,
     )
 
 
@@ -102,10 +109,16 @@ def record_completion_latency(
     metrics.chat_completion_latency.labels(result=result, **labels).observe(
         elapsed_seconds
     )
+    metrics.chat_completion_latency_by_country.labels(
+        result=result, client_country=clamp_launch_country(req.client_country)
+    ).observe(elapsed_seconds)
 
 
-def record_ttft(model: str, elapsed_seconds: float) -> None:
-    metrics.chat_completion_ttft.labels(model=model).observe(elapsed_seconds)
+def record_ttft(req: AuthorizedChatRequest, elapsed_seconds: float) -> None:
+    metrics.chat_completion_ttft.labels(model=req.model).observe(elapsed_seconds)
+    metrics.chat_completion_ttft_by_country.labels(
+        client_country=clamp_launch_country(req.client_country)
+    ).observe(elapsed_seconds)
 
 
 def record_search_latency(result: PrometheusResult, elapsed_seconds: float) -> None:

--- a/src/mlpa/core/metrics.py
+++ b/src/mlpa/core/metrics.py
@@ -73,7 +73,7 @@ def record_chat_availability_for(
     model: str,
     service_type: str,
     purpose: str,
-    client_country: str = "",  # "" (not yet authorized) clamps to "other" below
+    client_country: str,  # "" (not yet authorized) clamps to "other" below
 ) -> None:
     outcome = availability_outcome_for(reason)
     metrics.chat_availability.labels(

--- a/src/mlpa/core/middleware/request_size.py
+++ b/src/mlpa/core/middleware/request_size.py
@@ -5,6 +5,7 @@ from mlpa.core.config import ERROR_CODE_REQUEST_TOO_LARGE, env
 from mlpa.core.logger import logger
 from mlpa.core.metrics import record_chat_availability_for
 from mlpa.core.prometheus_metrics import AvailabilityReason
+from mlpa.core.utils import get_client_country
 
 
 async def check_request_size_middleware(request: Request, call_next):
@@ -28,7 +29,7 @@ async def check_request_size_middleware(request: Request, call_next):
                         model="",
                         service_type=request.headers.get("service-type") or "",
                         purpose=request.headers.get("purpose") or "",
-                        client_country=request.headers.get("X-Geo-Country") or "",
+                        client_country=get_client_country(request),
                     )
                     return JSONResponse(
                         status_code=413,

--- a/src/mlpa/core/middleware/request_size.py
+++ b/src/mlpa/core/middleware/request_size.py
@@ -28,6 +28,7 @@ async def check_request_size_middleware(request: Request, call_next):
                         model="",
                         service_type=request.headers.get("service-type") or "",
                         purpose=request.headers.get("purpose") or "",
+                        client_country=request.headers.get("X-Geo-Country") or "",
                     )
                     return JSONResponse(
                         status_code=413,

--- a/src/mlpa/core/prometheus_metrics.py
+++ b/src/mlpa/core/prometheus_metrics.py
@@ -180,6 +180,9 @@ class PrometheusMetrics:
     chat_requests_with_tools: Counter
     chat_request_rejections: Counter
     chat_availability: Counter
+    chat_completion_latency_by_country: Histogram
+    chat_completion_ttft_by_country: Histogram
+    chat_availability_by_country: Counter
 
     # search
     search_latency: Histogram
@@ -352,6 +355,34 @@ def build_metrics(registry: CollectorRegistry = REGISTRY) -> PrometheusMetrics:
             "mlpa_chat_availability_total",
             "Interim availability outcomes for chat completions. outcome is success/failure/excluded/abort; reason is the bounded cause. Availability = success / (success + failure).",
             ["outcome", "reason", "model", "service_type", "purpose"],
+            registry=registry,
+        ),
+        chat_completion_latency_by_country=Histogram(
+            "mlpa_chat_completion_latency_by_country_seconds",
+            "Chat completion latency in seconds, by launch-market client country "
+            "(AIPLAT-1266). Deliberately thin (no model/service_type/purpose) to "
+            "keep cardinality bounded; client_country is one of "
+            "LAUNCH_COUNTRIES or 'other'.",
+            ["result", "client_country"],
+            buckets=BUCKETS_COMPLETION,
+            registry=registry,
+        ),
+        chat_completion_ttft_by_country=Histogram(
+            "mlpa_chat_completion_ttft_by_country_seconds",
+            "Time to first token for streaming chat completions, by launch-market "
+            "client country (AIPLAT-1266). See chat_completion_latency_by_country "
+            "for the cardinality rationale.",
+            ["client_country"],
+            buckets=BUCKETS_TTFT,
+            registry=registry,
+        ),
+        chat_availability_by_country=Counter(
+            "mlpa_chat_availability_by_country_total",
+            "Interim availability outcomes for chat completions, by launch-market "
+            "client country (AIPLAT-1266). outcome only (no reason breakdown) to "
+            "keep cardinality bounded; see chat_availability for the full reason "
+            "breakdown without country.",
+            ["outcome", "client_country"],
             registry=registry,
         ),
         search_latency=Histogram(

--- a/src/mlpa/core/search.py
+++ b/src/mlpa/core/search.py
@@ -26,7 +26,10 @@ async def get_search(authorized_search_request: AuthorizedSearchRequest):
 async def _get_search(authorized_search_request: AuthorizedSearchRequest):
     start_time = time.perf_counter()
     body = sanitize_request_body(
-        authorized_search_request.model_dump(exclude_none=True)
+        authorized_search_request.model_dump(
+            exclude={"client_country"},
+            exclude_none=True,
+        )
     )
     result = PrometheusResult.ERROR
     logger.debug(

--- a/src/mlpa/core/search.py
+++ b/src/mlpa/core/search.py
@@ -27,7 +27,7 @@ async def _get_search(authorized_search_request: AuthorizedSearchRequest):
     start_time = time.perf_counter()
     body = sanitize_request_body(
         authorized_search_request.model_dump(
-            exclude={"client_country"},
+            exclude={"client_country", "service_type", "purpose", "user"},
             exclude_none=True,
         )
     )

--- a/src/mlpa/core/utils.py
+++ b/src/mlpa/core/utils.py
@@ -7,7 +7,7 @@ import time
 from functools import lru_cache
 from typing import Any, Literal, NoReturn, cast, overload
 
-from fastapi import HTTPException
+from fastapi import HTTPException, Request
 from fxa.oauth import Client
 from jwtoxide import DecodingKey, ValidationOptions, decode, encode
 
@@ -93,6 +93,11 @@ def _clamp_to_set(
 ) -> str:
     """Bound a raw label value to a known set, else `fallback`. Caps cardinality."""
     return raw if raw in valid else fallback
+
+
+def get_client_country(request: Request) -> str:
+    """Read the raw, edge-stamped ``X-Geo-Country`` header. Clamp at metric time."""
+    return request.headers.get("X-Geo-Country") or ""
 
 
 def clamp_country(raw: str | None) -> str:

--- a/src/mlpa/core/utils.py
+++ b/src/mlpa/core/utils.py
@@ -88,6 +88,13 @@ def clamp_major_fx_version(raw: str) -> str:
     return raw if raw == "" or raw in env.valid_major_fx_versions_set else "unknown"
 
 
+def _clamp_to_set(
+    raw: str | None, valid: frozenset[str] | set[str], fallback: str
+) -> str:
+    """Bound a raw label value to a known set, else `fallback`. Caps cardinality."""
+    return raw if raw in valid else fallback
+
+
 def clamp_country(raw: str | None) -> str:
     """Bound an edge-stamped client country to a known country code, else "unknown".
 
@@ -95,7 +102,17 @@ def clamp_country(raw: str | None) -> str:
     for aggregate metrics, never per-user data or logs. The clamp also caps label
     cardinality and blocks injection from a spoofed ``X-Geo-Country`` header.
     """
-    return raw if raw in COUNTRY_CODES else "unknown"
+    return _clamp_to_set(raw, COUNTRY_CODES, "unknown")
+
+
+def clamp_launch_country(raw: str) -> str:
+    """Bound a client country to the small Grafana-filterable launch-market set.
+
+    Distinct from `clamp_country`: this backs the dedicated by-country latency/
+    TTFT/availability metrics (AIPLAT-1266), which stay cheap only because this
+    set is a handful of values, not the full ISO list.
+    """
+    return _clamp_to_set(raw, env.MLPA_LAUNCH_COUNTRIES, "other")
 
 
 def clamp_request_method(method: str) -> str:

--- a/src/mlpa/run.py
+++ b/src/mlpa/run.py
@@ -245,7 +245,7 @@ async def search(
     ],
 ):
     record_request_country(
-        request.headers.get("X-Geo-Country"),
+        authorized_search_request.client_country,
         service_type=authorized_search_request.service_type,
         model=SEARCH_MODEL,
     )

--- a/src/mlpa/run.py
+++ b/src/mlpa/run.py
@@ -208,7 +208,7 @@ async def chat_completion(
     ],
 ):
     record_request_country(
-        request.headers.get("X-Geo-Country"),
+        authorized_chat_request.client_country,
         service_type=authorized_chat_request.service_type,
         model=authorized_chat_request.model,
     )

--- a/src/tests/unit/test_authorize.py
+++ b/src/tests/unit/test_authorize.py
@@ -11,12 +11,14 @@ from mlpa.core.classes import (
 )
 
 
-def _make_request(path: str = "/") -> Request:
+def _make_request(path: str = "/", headers: dict[str, str] | None = None) -> Request:
     async def receive() -> dict:
         return {"type": "http.request", "body": b"", "more_body": False}
 
+    raw_headers = [(k.lower().encode(), v.encode()) for k, v in (headers or {}).items()]
     return Request(
-        {"type": "http", "method": "POST", "path": path, "headers": []}, receive
+        {"type": "http", "method": "POST", "path": path, "headers": raw_headers},
+        receive,
     )
 
 
@@ -63,6 +65,63 @@ async def test_authorize_search_request_returns_authorized_search_request(mocker
     assert result.purpose == ""
     assert result.query == "latest AI developments"
     assert result.max_results == 2
+
+
+async def test_authorize_chat_request_captures_client_country(mocker):
+    """AIPLAT-1266: X-Geo-Country lands on AuthorizedChatRequest.client_country."""
+    mocker.patch.object(
+        authorize_module,
+        "fxa_auth",
+        mocker.AsyncMock(return_value={"user": "user-123"}),
+    )
+
+    result = await authorize_module.authorize_chat_request(
+        request=_make_request("/v1/chat/completions", headers={"X-Geo-Country": "FR"}),
+        chat_request=ChatRequest(
+            model="gpt-oss-120b", messages=[{"role": "user", "content": "hello"}]
+        ),
+        authorization="Bearer token",
+        service_type=authorize_module.ServiceType.ai,
+        purpose="chat",
+    )
+
+    assert result.client_country == "FR"
+
+
+async def test_authorize_chat_request_missing_geo_header_defaults_to_empty(mocker):
+    mocker.patch.object(
+        authorize_module,
+        "fxa_auth",
+        mocker.AsyncMock(return_value={"user": "user-123"}),
+    )
+
+    result = await authorize_module.authorize_chat_request(
+        request=_make_request("/v1/chat/completions"),
+        chat_request=ChatRequest(
+            model="gpt-oss-120b", messages=[{"role": "user", "content": "hello"}]
+        ),
+        authorization="Bearer token",
+        service_type=authorize_module.ServiceType.ai,
+        purpose="chat",
+    )
+
+    assert result.client_country == ""
+
+
+async def test_authorize_search_request_captures_client_country(mocker):
+    mocker.patch.object(
+        authorize_module,
+        "fxa_auth",
+        mocker.AsyncMock(return_value={"user": "user-456"}),
+    )
+
+    result = await authorize_module.authorize_search_request(
+        request=_make_request("/v1/search/", headers={"X-Geo-Country": "DE"}),
+        search_request=SearchRequest(query="latest AI developments", max_results=2),
+        authorization="Bearer token",
+    )
+
+    assert result.client_country == "DE"
 
 
 def test_search_request_rejects_too_many_results():

--- a/src/tests/unit/test_completions.py
+++ b/src/tests/unit/test_completions.py
@@ -66,6 +66,23 @@ def _proxy_error_records(records):
     ]
 
 
+# AIPLAT-1266: each of these gets a parallel bounded-country metric recorded
+# alongside it (see mlpa.core.metrics). `_expect_metrics` adds the twin
+# automatically so call sites don't repeat both names.
+_COUNTRY_METRIC_TWIN = {
+    "chat_availability": "chat_availability_by_country",
+    "chat_completion_latency": "chat_completion_latency_by_country",
+    "chat_completion_ttft": "chat_completion_ttft_by_country",
+}
+
+
+def _expect_metrics(*names: str) -> set[str]:
+    """Expected touched-metric set for `metrics_spy.assert_only`, with by-country twins."""
+    expected = set(names)
+    expected.update(_COUNTRY_METRIC_TWIN[n] for n in names if n in _COUNTRY_METRIC_TWIN)
+    return expected
+
+
 def _latency_count(spy, result: PrometheusResult, req=SAMPLE_REQUEST) -> float:
     model = req.model if result == PrometheusResult.SUCCESS else clamp_model(req.model)
     return spy.histogram_count(
@@ -172,7 +189,7 @@ async def test_get_completion_success(mocker, metrics_spy):
     assert "service_type" not in sent_json
 
     metrics_spy.assert_only(
-        {
+        _expect_metrics(
             "chat_availability",
             "chat_tokens",
             "chat_tokens_per_request",
@@ -183,7 +200,7 @@ async def test_get_completion_success(mocker, metrics_spy):
             "litellm_reported_duration_seconds",
             "litellm_reported_cost_usd_total",
             "litellm_routed_tokens",
-        }
+        )
     )
 
     chat_label_base = {
@@ -343,7 +360,12 @@ async def test_get_completion_http_error(mocker, metrics_spy):
     )
     assert _availability_total(metrics_spy) == 1
 
-    metrics_spy.assert_only({"chat_completion_latency", "chat_availability"})
+    metrics_spy.assert_only(
+        _expect_metrics(
+            "chat_completion_latency",
+            "chat_availability",
+        )
+    )
     assert _latency_count(metrics_spy, PrometheusResult.ERROR) == 1
 
 
@@ -359,7 +381,12 @@ async def test_get_completion_network_error(mocker, metrics_spy):
     assert exc_info.value.status_code == 502
     assert exc_info.value.detail["error"] == "Connection timed out"
 
-    metrics_spy.assert_only({"chat_completion_latency", "chat_availability"})
+    metrics_spy.assert_only(
+        _expect_metrics(
+            "chat_completion_latency",
+            "chat_availability",
+        )
+    )
     assert _latency_count(metrics_spy, PrometheusResult.ERROR) == 1
 
 
@@ -393,7 +420,7 @@ async def test_stream_completion_success(
     assert "service_type" not in request_body
 
     metrics_spy.assert_only(
-        {
+        _expect_metrics(
             "chat_availability",
             "chat_completion_ttft",
             "chat_tokens",
@@ -405,7 +432,7 @@ async def test_stream_completion_success(
             "litellm_reported_duration_seconds",
             "litellm_reported_cost_usd_total",
             "litellm_routed_tokens",
-        }
+        )
     )
 
     chat_label_base = {
@@ -515,7 +542,11 @@ async def test_get_completion_budget_limit_exceeded_429(mocker, metrics_spy):
     assert exc_info.value.headers == {"Retry-After": "86400"}
 
     metrics_spy.assert_only(
-        {"chat_request_rejections", "chat_completion_latency", "chat_availability"}
+        _expect_metrics(
+            "chat_request_rejections",
+            "chat_completion_latency",
+            "chat_availability",
+        )
     )
     assert _rejection_count(metrics_spy, PrometheusRejectionReason.BUDGET_EXCEEDED) == 1
     assert _latency_count(metrics_spy, PrometheusResult.ERROR) == 1
@@ -562,7 +593,11 @@ async def test_get_completion_budget_limit_exceeded_400(mocker, metrics_spy):
     assert exc_info.value.headers == {"Retry-After": "86400"}
 
     metrics_spy.assert_only(
-        {"chat_request_rejections", "chat_completion_latency", "chat_availability"}
+        _expect_metrics(
+            "chat_request_rejections",
+            "chat_completion_latency",
+            "chat_availability",
+        )
     )
     assert _rejection_count(metrics_spy, PrometheusRejectionReason.BUDGET_EXCEEDED) == 1
 
@@ -605,7 +640,11 @@ async def test_get_completion_rate_limit_exceeded(mocker, metrics_spy):
     )
 
     metrics_spy.assert_only(
-        {"chat_request_rejections", "chat_completion_latency", "chat_availability"}
+        _expect_metrics(
+            "chat_request_rejections",
+            "chat_completion_latency",
+            "chat_availability",
+        )
     )
     assert _rejection_count(metrics_spy, PrometheusRejectionReason.RATE_LIMITED) == 1
 
@@ -638,7 +677,12 @@ async def test_get_completion_400_non_rate_limit_error(mocker, metrics_spy):
 
     assert exc_info.value.status_code == 400
     assert exc_info.value.detail == {"error": "Upstream service returned an error"}
-    metrics_spy.assert_only({"chat_completion_latency", "chat_availability"})
+    metrics_spy.assert_only(
+        _expect_metrics(
+            "chat_completion_latency",
+            "chat_availability",
+        )
+    )
 
 
 async def test_get_completion_429_non_rate_limit_error(mocker, metrics_spy):
@@ -663,7 +707,12 @@ async def test_get_completion_429_non_rate_limit_error(mocker, metrics_spy):
 
     assert exc_info.value.status_code == 429
     assert exc_info.value.detail == {"error": "Upstream service returned an error"}
-    metrics_spy.assert_only({"chat_completion_latency", "chat_availability"})
+    metrics_spy.assert_only(
+        _expect_metrics(
+            "chat_completion_latency",
+            "chat_availability",
+        )
+    )
 
 
 async def test_get_completion_upstream_rate_limit_error(mocker, metrics_spy):
@@ -697,7 +746,11 @@ async def test_get_completion_upstream_rate_limit_error(mocker, metrics_spy):
         == 1
     )
     metrics_spy.assert_only(
-        {"chat_request_rejections", "chat_completion_latency", "chat_availability"}
+        _expect_metrics(
+            "chat_request_rejections",
+            "chat_completion_latency",
+            "chat_availability",
+        )
     )
     assert _rejection_count(metrics_spy, PrometheusRejectionReason.RATE_LIMITED) == 1
     assert _latency_count(metrics_spy, PrometheusResult.ERROR) == 1
@@ -730,7 +783,11 @@ async def test_get_completion_context_window_exceeded(mocker, metrics_spy):
     mock_logger.warning.assert_called_once()
     assert "Context window exceeded" in str(mock_logger.warning.call_args)
     metrics_spy.assert_only(
-        {"chat_request_rejections", "chat_completion_latency", "chat_availability"}
+        _expect_metrics(
+            "chat_request_rejections",
+            "chat_completion_latency",
+            "chat_availability",
+        )
     )
     assert (
         _rejection_count(metrics_spy, PrometheusRejectionReason.PAYLOAD_TOO_LARGE) == 1
@@ -767,7 +824,11 @@ async def test_get_completion_invalid_model_name(mocker, metrics_spy):
     mock_logger.warning.assert_called_once()
     assert "Invalid model name" in str(mock_logger.warning.call_args)
     metrics_spy.assert_only(
-        {"chat_request_rejections", "chat_completion_latency", "chat_availability"}
+        _expect_metrics(
+            "chat_request_rejections",
+            "chat_completion_latency",
+            "chat_availability",
+        )
     )
     assert (
         _rejection_count(metrics_spy, PrometheusRejectionReason.INVALID_MODEL_NAME) == 1
@@ -803,7 +864,11 @@ async def test_get_completion_invalid_request_vertex(mocker, metrics_spy):
     mock_logger.warning.assert_called_once()
     assert "Invalid request" in str(mock_logger.warning.call_args)
     metrics_spy.assert_only(
-        {"chat_request_rejections", "chat_completion_latency", "chat_availability"}
+        _expect_metrics(
+            "chat_request_rejections",
+            "chat_completion_latency",
+            "chat_availability",
+        )
     )
     assert _rejection_count(metrics_spy, PrometheusRejectionReason.INVALID_REQUEST) == 1
     assert _latency_count(metrics_spy, PrometheusResult.ERROR) == 1
@@ -829,7 +894,12 @@ async def test_get_completion_429_invalid_json(mocker, metrics_spy):
 
     assert exc_info.value.status_code == 429
     assert exc_info.value.detail == {"error": "Upstream service returned an error"}
-    metrics_spy.assert_only({"chat_completion_latency", "chat_availability"})
+    metrics_spy.assert_only(
+        _expect_metrics(
+            "chat_completion_latency",
+            "chat_availability",
+        )
+    )
 
 
 async def test_stream_completion_budget_limit_exceeded_429(
@@ -866,7 +936,11 @@ async def test_stream_completion_budget_limit_exceeded_429(
     mock_logger.warning.assert_called_once()
     assert "Budget limit exceeded" in str(mock_logger.warning.call_args)
     metrics_spy.assert_only(
-        {"chat_request_rejections", "chat_completion_latency", "chat_availability"}
+        _expect_metrics(
+            "chat_request_rejections",
+            "chat_completion_latency",
+            "chat_availability",
+        )
     )
     assert _rejection_count(metrics_spy, PrometheusRejectionReason.BUDGET_EXCEEDED) == 1
     assert _latency_count(metrics_spy, PrometheusResult.ERROR) == 1
@@ -916,7 +990,11 @@ async def test_stream_completion_budget_limit_exceeded_400(
     mock_logger.warning.assert_called_once()
     assert "Budget limit exceeded" in str(mock_logger.warning.call_args)
     metrics_spy.assert_only(
-        {"chat_request_rejections", "chat_completion_latency", "chat_availability"}
+        _expect_metrics(
+            "chat_request_rejections",
+            "chat_completion_latency",
+            "chat_availability",
+        )
     )
     assert _rejection_count(metrics_spy, PrometheusRejectionReason.BUDGET_EXCEEDED) == 1
     assert _latency_count(metrics_spy, PrometheusResult.ERROR) == 1
@@ -957,7 +1035,11 @@ async def test_stream_completion_rate_limit_exceeded(
     mock_logger.warning.assert_called_once()
     assert "Rate limit exceeded" in str(mock_logger.warning.call_args)
     metrics_spy.assert_only(
-        {"chat_request_rejections", "chat_completion_latency", "chat_availability"}
+        _expect_metrics(
+            "chat_request_rejections",
+            "chat_completion_latency",
+            "chat_availability",
+        )
     )
     assert _rejection_count(metrics_spy, PrometheusRejectionReason.RATE_LIMITED) == 1
     assert _latency_count(metrics_spy, PrometheusResult.ERROR) == 1
@@ -993,7 +1075,11 @@ async def test_stream_completion_context_window_exceeded(
     mock_logger.warning.assert_called_once()
     assert "Context window exceeded" in str(mock_logger.warning.call_args)
     metrics_spy.assert_only(
-        {"chat_request_rejections", "chat_completion_latency", "chat_availability"}
+        _expect_metrics(
+            "chat_request_rejections",
+            "chat_completion_latency",
+            "chat_availability",
+        )
     )
     assert (
         _rejection_count(metrics_spy, PrometheusRejectionReason.PAYLOAD_TOO_LARGE) == 1
@@ -1033,7 +1119,11 @@ async def test_stream_completion_invalid_model_name(
     mock_logger.warning.assert_called_once()
     assert "Invalid model name" in str(mock_logger.warning.call_args)
     metrics_spy.assert_only(
-        {"chat_request_rejections", "chat_completion_latency", "chat_availability"}
+        _expect_metrics(
+            "chat_request_rejections",
+            "chat_completion_latency",
+            "chat_availability",
+        )
     )
     assert (
         _rejection_count(metrics_spy, PrometheusRejectionReason.INVALID_MODEL_NAME) == 1
@@ -1072,7 +1162,11 @@ async def test_stream_completion_invalid_request_vertex(
     mock_logger.warning.assert_called_once()
     assert "Invalid request" in str(mock_logger.warning.call_args)
     metrics_spy.assert_only(
-        {"chat_request_rejections", "chat_completion_latency", "chat_availability"}
+        _expect_metrics(
+            "chat_request_rejections",
+            "chat_completion_latency",
+            "chat_availability",
+        )
     )
     assert _rejection_count(metrics_spy, PrometheusRejectionReason.INVALID_REQUEST) == 1
     assert _latency_count(metrics_spy, PrometheusResult.ERROR) == 1
@@ -1112,7 +1206,12 @@ async def test_stream_completion_400_non_rate_limit_error(
         == b'data: {"code": 400, "error": "Upstream service returned an error"}\n\n'
     )
     mock_logger.opt.return_value.error.assert_called_once()
-    metrics_spy.assert_only({"chat_completion_latency", "chat_availability"})
+    metrics_spy.assert_only(
+        _expect_metrics(
+            "chat_completion_latency",
+            "chat_availability",
+        )
+    )
     assert _latency_count(metrics_spy, PrometheusResult.ERROR) == 1
 
 
@@ -1144,7 +1243,12 @@ async def test_stream_completion_429_non_rate_limit_error(
         == b'data: {"code": 429, "error": "Upstream service returned an error"}\n\n'
     )
     mock_logger.opt.return_value.error.assert_called_once()
-    metrics_spy.assert_only({"chat_completion_latency", "chat_availability"})
+    metrics_spy.assert_only(
+        _expect_metrics(
+            "chat_completion_latency",
+            "chat_availability",
+        )
+    )
     assert _latency_count(metrics_spy, PrometheusResult.ERROR) == 1
 
 
@@ -1169,7 +1273,11 @@ async def test_stream_completion_upstream_rate_limit_error(
         f'data: {{"error": {ERROR_CODE_UPSTREAM_RATE_LIMIT_EXCEEDED}}}\n\n'.encode()
     ]
     metrics_spy.assert_only(
-        {"chat_request_rejections", "chat_completion_latency", "chat_availability"}
+        _expect_metrics(
+            "chat_request_rejections",
+            "chat_completion_latency",
+            "chat_availability",
+        )
     )
     assert _rejection_count(metrics_spy, PrometheusRejectionReason.RATE_LIMITED) == 1
     assert _latency_count(metrics_spy, PrometheusResult.ERROR) == 1
@@ -1200,7 +1308,12 @@ async def test_stream_completion_429_invalid_json(
         == b'data: {"code": 429, "error": "Upstream service returned an error"}\n\n'
     )
     mock_logger.opt.return_value.error.assert_called_once()
-    metrics_spy.assert_only({"chat_completion_latency", "chat_availability"})
+    metrics_spy.assert_only(
+        _expect_metrics(
+            "chat_completion_latency",
+            "chat_availability",
+        )
+    )
     assert _latency_count(metrics_spy, PrometheusResult.ERROR) == 1
 
 
@@ -1220,7 +1333,12 @@ async def test_stream_completion_exception_after_streaming_started(
 
     assert len(received_chunks) == 1
     assert b"error" in received_chunks[0]
-    metrics_spy.assert_only({"chat_completion_latency", "chat_availability"})
+    metrics_spy.assert_only(
+        _expect_metrics(
+            "chat_completion_latency",
+            "chat_availability",
+        )
+    )
     assert _latency_count(metrics_spy, PrometheusResult.ERROR) == 1
 
 

--- a/src/tests/unit/test_completions.py
+++ b/src/tests/unit/test_completions.py
@@ -139,6 +139,36 @@ def _availability_total(spy, req=SAMPLE_REQUEST) -> float:
     )
 
 
+def _country_latency_count(
+    spy, result: PrometheusResult, client_country: str = "other"
+) -> float:
+    """Count for the by-country latency histogram twin of `_latency_count`.
+
+    Unlike `_latency_count`, checks the actual `client_country` label value
+    (default "other" since SAMPLE_REQUEST.client_country is "" and clamps to
+    "other") rather than only asserting the metric name was touched.
+    """
+    return spy.histogram_count(
+        "chat_completion_latency_by_country",
+        result=result,
+        client_country=client_country,
+    )
+
+
+def _country_ttft_count(spy, client_country: str = "other") -> float:
+    return spy.histogram_count(
+        "chat_completion_ttft_by_country", client_country=client_country
+    )
+
+
+def _country_availability_count(
+    spy, outcome: AvailabilityOutcome, client_country: str = "other"
+) -> float:
+    return spy.value(
+        "chat_availability_by_country", outcome=outcome, client_country=client_country
+    )
+
+
 def _sample_litellm_response_headers(**overrides: str) -> httpx.Headers:
     base = {
         LITELLM_HEADER_MODEL_API_BASE: "https://api.together.xyz/v1",
@@ -217,6 +247,7 @@ async def test_get_completion_success(mocker, metrics_spy):
         == SUCCESSFUL_CHAT_RESPONSE["usage"]["completion_tokens"]
     )
     assert _latency_count(metrics_spy, PrometheusResult.SUCCESS) == 1
+    assert _country_latency_count(metrics_spy, PrometheusResult.SUCCESS) == 1
     assert (
         _availability_count(
             metrics_spy,
@@ -225,6 +256,7 @@ async def test_get_completion_success(mocker, metrics_spy):
         )
         == 1
     )
+    assert _country_availability_count(metrics_spy, AvailabilityOutcome.SUCCESS) == 1
 
     routing = _litellm_routing_label_base()
     assert (
@@ -443,6 +475,7 @@ async def test_stream_completion_success(
     assert metrics_spy.value("chat_tokens", type="prompt", **chat_label_base) == 10
     assert metrics_spy.value("chat_tokens", type="completion", **chat_label_base) == 25
     assert _latency_count(metrics_spy, PrometheusResult.SUCCESS) == 1
+    assert _country_latency_count(metrics_spy, PrometheusResult.SUCCESS) == 1
     assert (
         _availability_count(
             metrics_spy,
@@ -451,10 +484,12 @@ async def test_stream_completion_success(
         )
         == 1
     )
+    assert _country_availability_count(metrics_spy, AvailabilityOutcome.SUCCESS) == 1
     assert (
         metrics_spy.histogram_count("chat_completion_ttft", model=SAMPLE_REQUEST.model)
         == 1
     )
+    assert _country_ttft_count(metrics_spy) == 1
 
     routing = _litellm_routing_label_base()
     assert (
@@ -638,6 +673,7 @@ async def test_get_completion_rate_limit_exceeded(mocker, metrics_spy):
         )
         == 1
     )
+    assert _country_availability_count(metrics_spy, AvailabilityOutcome.EXCLUDED) == 1
 
     metrics_spy.assert_only(
         _expect_metrics(

--- a/src/tests/unit/test_metrics.py
+++ b/src/tests/unit/test_metrics.py
@@ -6,6 +6,7 @@ from mlpa.core.metrics import (
     record_request_country,
     record_request_with_tools,
     record_tool_metrics,
+    record_ttft,
 )
 from mlpa.core.prometheus_metrics import (
     AvailabilityReason,
@@ -15,12 +16,15 @@ from mlpa.core.prometheus_metrics import (
 from mlpa.core.utils import clamp_model
 
 
-def _chat_request(model: str = "openai/gpt-4o") -> AuthorizedChatRequest:
+def _chat_request(
+    model: str = "openai/gpt-4o", client_country: str = ""
+) -> AuthorizedChatRequest:
     return AuthorizedChatRequest(
         user="test-user:ai",
         service_type="ai",
         purpose="chat",
         model=model,
+        client_country=client_country,
         messages=[{"role": "user", "content": "hi"}],
         tools=[
             {"type": "function", "function": {"name": "first_tool"}},
@@ -212,6 +216,62 @@ def test_configured_models_keep_their_metric_label(metrics_spy):
             service_type=req.service_type,
             model=req.model,
             client_country="DE",
+        )
+        == 1
+    )
+
+
+def test_by_country_metrics_use_launch_market_bucketing(metrics_spy):
+    """AIPLAT-1266: the by-country metrics are thin (no model/service_type/purpose)
+    and bucket anything outside LAUNCH_COUNTRIES as "other", unlike clamp_country.
+    """
+    launch_market_req = _chat_request(client_country="FR")
+    other_country_req = _chat_request(client_country="BR")
+
+    record_completion_latency(launch_market_req, PrometheusResult.SUCCESS, 0.5)
+    record_completion_latency(other_country_req, PrometheusResult.SUCCESS, 0.5)
+    record_ttft(launch_market_req, 0.2)
+    record_ttft(other_country_req, 0.2)
+    record_chat_availability(launch_market_req, AvailabilityReason.VALID_RESPONSE)
+    record_chat_availability(other_country_req, AvailabilityReason.VALID_RESPONSE)
+
+    assert (
+        metrics_spy.histogram_count(
+            "chat_completion_latency_by_country",
+            result=PrometheusResult.SUCCESS,
+            client_country="FR",
+        )
+        == 1
+    )
+    assert (
+        metrics_spy.histogram_count(
+            "chat_completion_latency_by_country",
+            result=PrometheusResult.SUCCESS,
+            client_country="other",
+        )
+        == 1
+    )
+    assert (
+        metrics_spy.histogram_count(
+            "chat_completion_ttft_by_country", client_country="FR"
+        )
+        == 1
+    )
+    assert (
+        metrics_spy.histogram_count(
+            "chat_completion_ttft_by_country", client_country="other"
+        )
+        == 1
+    )
+    assert (
+        metrics_spy.value(
+            "chat_availability_by_country", outcome="success", client_country="FR"
+        )
+        == 1
+    )
+    assert (
+        metrics_spy.value(
+            "chat_availability_by_country", outcome="success", client_country="other"
         )
         == 1
     )

--- a/src/tests/unit/test_search.py
+++ b/src/tests/unit/test_search.py
@@ -56,6 +56,37 @@ async def test_get_search_handles_unpaired_surrogate(mocker):
     assert sent_json["query"].startswith("weather in tokyo ")
 
 
+async def test_get_search_excludes_internal_fields_from_upstream_body(mocker):
+    """client_country/service_type/purpose/user are internal auth/routing fields;
+    they must never be forwarded to the Exa search backend."""
+    mock_response = MagicMock()
+    mock_response.json.return_value = {"results": []}
+    mock_response.raise_for_status.return_value = None
+
+    mock_client = AsyncMock()
+    mock_client.post.return_value = mock_response
+    mocker.patch("mlpa.core.search.get_http_client", return_value=mock_client)
+
+    req = AuthorizedSearchRequest(
+        user="test-user:search",
+        service_type="search",
+        purpose="",
+        client_country="US",
+        query="weather in tokyo",
+        max_results=5,
+    )
+
+    await get_search(req)
+
+    _, call_kwargs = mock_client.post.call_args
+    sent_json = call_kwargs["json"]
+    assert "client_country" not in sent_json
+    assert "service_type" not in sent_json
+    assert "purpose" not in sent_json
+    assert "user" not in sent_json
+    assert sent_json == {"query": "weather in tokyo", "max_results": 5}
+
+
 async def test_get_search_sanitizes_response_surrogates(mocker):
     """Upstream search results with a lone surrogate must be cleaned before return."""
     mock_response = MagicMock()

--- a/src/tests/unit/test_utils.py
+++ b/src/tests/unit/test_utils.py
@@ -7,6 +7,7 @@ from mlpa.core.config import env
 from mlpa.core.utils import (
     b64decode_safe,
     clamp_country,
+    clamp_launch_country,
     clamp_purpose,
     clamp_service_type,
     is_context_window_error,
@@ -361,3 +362,20 @@ def test_clamp_purpose_preserves_missing_value(raw, expected):
 )
 def test_clamp_country(raw, expected):
     assert clamp_country(raw) == expected
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("US", "US"),
+        ("CA", "CA"),
+        ("FR", "FR"),
+        ("DE", "DE"),
+        ("GB", "other"),
+        ("us", "other"),
+        ("", "other"),
+        ("DE; rm -rf", "other"),
+    ],
+)
+def test_clamp_launch_country(raw, expected):
+    assert clamp_launch_country(raw) == expected


### PR DESCRIPTION
We want country/region breakdown for chat metrics in Grafana.

Adds a bounded per-country dimension to chat completion latency, TTFT, and availability metrics. Only few markets (US, CA, FR, DE) get their own label, everything else buckets into "other" so we don't blow up cardinality (211 countries seen in prod today, see ).

Added a docs/prometheus-cardinality.md for future references


[AIPLAT-1266](https://mozilla-hub.atlassian.net/browse/AIPLAT-1266)