### PR TITLE
feat(country-metrics): AIPLAT-1266 service_type label

### DIFF
--- a/src/mlpa/core/metrics.py
+++ b/src/mlpa/core/metrics.py
@@ -84,7 +84,9 @@ def record_chat_availability_for(
         purpose=clamp_purpose(purpose),
     ).inc()
     metrics.chat_availability_by_country.labels(
-        outcome=outcome, client_country=clamp_launch_country(client_country)
+        outcome=outcome,
+        client_country=clamp_launch_country(client_country),
+        service_type=clamp_service_type(service_type),
     ).inc()
 
 
@@ -110,14 +112,17 @@ def record_completion_latency(
         elapsed_seconds
     )
     metrics.chat_completion_latency_by_country.labels(
-        result=result, client_country=clamp_launch_country(req.client_country)
+        result=result,
+        client_country=clamp_launch_country(req.client_country),
+        service_type=clamp_service_type(req.service_type),
     ).observe(elapsed_seconds)
 
 
 def record_ttft(req: AuthorizedChatRequest, elapsed_seconds: float) -> None:
     metrics.chat_completion_ttft.labels(model=req.model).observe(elapsed_seconds)
     metrics.chat_completion_ttft_by_country.labels(
-        client_country=clamp_launch_country(req.client_country)
+        client_country=clamp_launch_country(req.client_country),
+        service_type=clamp_service_type(req.service_type),
     ).observe(elapsed_seconds)
 
 

--- a/src/mlpa/core/prometheus_metrics.py
+++ b/src/mlpa/core/prometheus_metrics.py
@@ -360,29 +360,29 @@ def build_metrics(registry: CollectorRegistry = REGISTRY) -> PrometheusMetrics:
         chat_completion_latency_by_country=Histogram(
             "mlpa_chat_completion_latency_by_country_seconds",
             "Chat completion latency in seconds, by launch-market client country "
-            "(AIPLAT-1266). Deliberately thin (no model/service_type/purpose) to "
-            "keep cardinality bounded; client_country is one of "
+            "and service_type (AIPLAT-1266). Deliberately thin (no model/purpose) "
+            "to keep cardinality bounded; client_country is one of "
             "LAUNCH_COUNTRIES or 'other'.",
-            ["result", "client_country"],
+            ["result", "client_country", "service_type"],
             buckets=BUCKETS_COMPLETION,
             registry=registry,
         ),
         chat_completion_ttft_by_country=Histogram(
             "mlpa_chat_completion_ttft_by_country_seconds",
             "Time to first token for streaming chat completions, by launch-market "
-            "client country (AIPLAT-1266). See chat_completion_latency_by_country "
+            "client country and service_type. See chat_completion_latency_by_country "
             "for the cardinality rationale.",
-            ["client_country"],
+            ["client_country", "service_type"],
             buckets=BUCKETS_TTFT,
             registry=registry,
         ),
         chat_availability_by_country=Counter(
             "mlpa_chat_availability_by_country_total",
             "Interim availability outcomes for chat completions, by launch-market "
-            "client country (AIPLAT-1266). outcome only (no reason breakdown) to "
-            "keep cardinality bounded; see chat_availability for the full reason "
-            "breakdown without country.",
-            ["outcome", "client_country"],
+            "client country and service_type (AIPLAT-1266). outcome only (no reason "
+            "breakdown) to keep cardinality bounded; see chat_availability for the "
+            "full reason breakdown without country.",
+            ["outcome", "client_country", "service_type"],
             registry=registry,
         ),
         search_latency=Histogram(

--- a/src/tests/unit/test_completions.py
+++ b/src/tests/unit/test_completions.py
@@ -140,7 +140,10 @@ def _availability_total(spy, req=SAMPLE_REQUEST) -> float:
 
 
 def _country_latency_count(
-    spy, result: PrometheusResult, client_country: str = "other"
+    spy,
+    result: PrometheusResult,
+    client_country: str = "other",
+    service_type: str = "ai",
 ) -> float:
     """Count for the by-country latency histogram twin of `_latency_count`.
 
@@ -152,20 +155,31 @@ def _country_latency_count(
         "chat_completion_latency_by_country",
         result=result,
         client_country=client_country,
+        service_type=service_type,
     )
 
 
-def _country_ttft_count(spy, client_country: str = "other") -> float:
+def _country_ttft_count(
+    spy, client_country: str = "other", service_type: str = "ai"
+) -> float:
     return spy.histogram_count(
-        "chat_completion_ttft_by_country", client_country=client_country
+        "chat_completion_ttft_by_country",
+        client_country=client_country,
+        service_type=service_type,
     )
 
 
 def _country_availability_count(
-    spy, outcome: AvailabilityOutcome, client_country: str = "other"
+    spy,
+    outcome: AvailabilityOutcome,
+    client_country: str = "other",
+    service_type: str = "ai",
 ) -> float:
     return spy.value(
-        "chat_availability_by_country", outcome=outcome, client_country=client_country
+        "chat_availability_by_country",
+        outcome=outcome,
+        client_country=client_country,
+        service_type=service_type,
     )
 
 

--- a/src/tests/unit/test_metrics.py
+++ b/src/tests/unit/test_metrics.py
@@ -222,8 +222,9 @@ def test_configured_models_keep_their_metric_label(metrics_spy):
 
 
 def test_by_country_metrics_use_launch_market_bucketing(metrics_spy):
-    """AIPLAT-1266: the by-country metrics are thin (no model/service_type/purpose)
-    and bucket anything outside LAUNCH_COUNTRIES as "other", unlike clamp_country.
+    """AIPLAT-1266: the by-country metrics are thin (no model/purpose, but do
+    carry service_type) and bucket anything outside LAUNCH_COUNTRIES as
+    "other", unlike clamp_country.
     """
     launch_market_req = _chat_request(client_country="FR")
     other_country_req = _chat_request(client_country="BR")
@@ -240,6 +241,7 @@ def test_by_country_metrics_use_launch_market_bucketing(metrics_spy):
             "chat_completion_latency_by_country",
             result=PrometheusResult.SUCCESS,
             client_country="FR",
+            service_type="ai",
         )
         == 1
     )
@@ -248,30 +250,39 @@ def test_by_country_metrics_use_launch_market_bucketing(metrics_spy):
             "chat_completion_latency_by_country",
             result=PrometheusResult.SUCCESS,
             client_country="other",
+            service_type="ai",
         )
         == 1
     )
     assert (
         metrics_spy.histogram_count(
-            "chat_completion_ttft_by_country", client_country="FR"
+            "chat_completion_ttft_by_country", client_country="FR", service_type="ai"
         )
         == 1
     )
     assert (
         metrics_spy.histogram_count(
-            "chat_completion_ttft_by_country", client_country="other"
+            "chat_completion_ttft_by_country",
+            client_country="other",
+            service_type="ai",
         )
         == 1
     )
     assert (
         metrics_spy.value(
-            "chat_availability_by_country", outcome="success", client_country="FR"
+            "chat_availability_by_country",
+            outcome="success",
+            client_country="FR",
+            service_type="ai",
         )
         == 1
     )
     assert (
         metrics_spy.value(
-            "chat_availability_by_country", outcome="success", client_country="other"
+            "chat_availability_by_country",
+            outcome="success",
+            client_country="other",
+            service_type="ai",
         )
         == 1
     )


### PR DESCRIPTION
Follow-up to #234, adds `service_type` label to the by-country latency/TTFT/availability metrics.

[AIPLAT-1266](https://mozilla-hub.atlassian.net/browse/AIPLAT-1266)