### PR TITLE
feat(completions): propagate purpose to spend logs

### DIFF
--- a/src/mlpa/core/completions.py
+++ b/src/mlpa/core/completions.py
@@ -48,8 +48,9 @@ def _build_litellm_body(req: AuthorizedChatRequest, *, stream: bool) -> dict:
     body["stream"] = stream
     if stream:
         body["stream_options"] = {"include_usage": True}
-    # Surfaces `purpose` on LiteLLM_SpendLogs.metadata for cost/usage analysis by
-    # business purpose (service_type already rides in `user`, see AIPLAT-1266).
+    # tags would be litellm-native but spend-by-tag reporting is Enterprise-only
+    # and tags are flat strings, harder to query in BQ. JSON metadata is OSS and
+    # queryable as a plain key.
     body["metadata"] = {"spend_logs_metadata": {"purpose": req.purpose}}
     return sanitize_request_body(body)
 

--- a/src/mlpa/core/completions.py
+++ b/src/mlpa/core/completions.py
@@ -48,6 +48,9 @@ def _build_litellm_body(req: AuthorizedChatRequest, *, stream: bool) -> dict:
     body["stream"] = stream
     if stream:
         body["stream_options"] = {"include_usage": True}
+    # Surfaces `purpose` on LiteLLM_SpendLogs.metadata for cost/usage analysis by
+    # business purpose (service_type already rides in `user`, see AIPLAT-1266).
+    body["metadata"] = {"spend_logs_metadata": {"purpose": req.purpose}}
     return sanitize_request_body(body)
 
 

--- a/src/mlpa/core/completions.py
+++ b/src/mlpa/core/completions.py
@@ -51,7 +51,12 @@ def _build_litellm_body(req: AuthorizedChatRequest, *, stream: bool) -> dict:
     # tags would be litellm-native but spend-by-tag reporting is Enterprise-only
     # and tags are flat strings, harder to query in BQ. JSON metadata is OSS and
     # queryable as a plain key.
-    body["metadata"] = {"spend_logs_metadata": {"purpose": req.purpose}}
+    body["metadata"] = {
+        "spend_logs_metadata": {
+            "purpose": req.purpose,
+            "country_code": req.client_country,
+        }
+    }
     return sanitize_request_body(body)
 
 

--- a/src/tests/unit/test_completions.py
+++ b/src/tests/unit/test_completions.py
@@ -1726,6 +1726,44 @@ def test_build_litellm_body_handles_unpaired_surrogate():
     assert encoded.decode("utf-8")
 
 
+def test_build_litellm_body_includes_purpose_in_spend_logs_metadata():
+    """`purpose` is dropped from the top-level body (not an OpenAI chat param)
+    but surfaced under metadata.spend_logs_metadata so it lands on
+    LiteLLM_SpendLogs.metadata for cost/usage analysis by business purpose."""
+    req = AuthorizedChatRequest(
+        user="test-user-123:memories",
+        service_type="memories",
+        purpose="memory-generation",
+        model="test-model",
+        messages=[{"role": "user", "content": "hi"}],
+        max_completion_tokens=150,
+    )
+
+    body = _build_litellm_body(req, stream=False)
+
+    assert body["metadata"] == {"spend_logs_metadata": {"purpose": "memory-generation"}}
+    assert "purpose" not in body
+    assert "service_type" not in body
+    assert "client_country" not in body
+
+
+def test_build_litellm_body_includes_empty_purpose_for_service_types_without_one():
+    """Service types with no configured purposes (e.g. s2s) carry purpose=""
+    rather than omitting the key, so the metadata shape stays consistent."""
+    req = AuthorizedChatRequest(
+        user="test-user-123:s2s",
+        service_type="s2s",
+        purpose="",
+        model="test-model",
+        messages=[{"role": "user", "content": "hi"}],
+        max_completion_tokens=150,
+    )
+
+    body = _build_litellm_body(req, stream=False)
+
+    assert body["metadata"] == {"spend_logs_metadata": {"purpose": ""}}
+
+
 async def test_get_completion_sanitizes_response_surrogates(mocker):
     """Upstream content with a lone surrogate must be cleaned before we return it,
     otherwise FastAPI's JSON encoder 500s when serializing the response."""

--- a/src/tests/unit/test_completions.py
+++ b/src/tests/unit/test_completions.py
@@ -1726,14 +1726,15 @@ def test_build_litellm_body_handles_unpaired_surrogate():
     assert encoded.decode("utf-8")
 
 
-def test_build_litellm_body_includes_purpose_in_spend_logs_metadata():
-    """`purpose` is dropped from the top-level body (not an OpenAI chat param)
-    but surfaced under metadata.spend_logs_metadata so it lands on
-    LiteLLM_SpendLogs.metadata for cost/usage analysis by business purpose."""
+def test_build_litellm_body_includes_purpose_and_country_in_spend_logs_metadata():
+    """`purpose` and `client_country` are dropped from the top-level body (not
+    OpenAI chat params) but surfaced under metadata.spend_logs_metadata so they
+    land on LiteLLM_SpendLogs.metadata for cost/usage analysis."""
     req = AuthorizedChatRequest(
         user="test-user-123:memories",
         service_type="memories",
         purpose="memory-generation",
+        client_country="DE",
         model="test-model",
         messages=[{"role": "user", "content": "hi"}],
         max_completion_tokens=150,
@@ -1741,19 +1742,23 @@ def test_build_litellm_body_includes_purpose_in_spend_logs_metadata():
 
     body = _build_litellm_body(req, stream=False)
 
-    assert body["metadata"] == {"spend_logs_metadata": {"purpose": "memory-generation"}}
+    assert body["metadata"] == {
+        "spend_logs_metadata": {"purpose": "memory-generation", "country_code": "DE"}
+    }
     assert "purpose" not in body
     assert "service_type" not in body
     assert "client_country" not in body
 
 
-def test_build_litellm_body_includes_empty_purpose_for_service_types_without_one():
-    """Service types with no configured purposes (e.g. s2s) carry purpose=""
-    rather than omitting the key, so the metadata shape stays consistent."""
+def test_build_litellm_body_includes_empty_purpose_and_country_when_unset():
+    """Service types with no configured purposes (e.g. s2s) carry purpose="",
+    and requests with no edge-stamped geo header carry client_country="" -
+    both rather than omitting the key, so the metadata shape stays consistent."""
     req = AuthorizedChatRequest(
         user="test-user-123:s2s",
         service_type="s2s",
         purpose="",
+        client_country="",
         model="test-model",
         messages=[{"role": "user", "content": "hi"}],
         max_completion_tokens=150,
@@ -1761,7 +1766,9 @@ def test_build_litellm_body_includes_empty_purpose_for_service_types_without_one
 
     body = _build_litellm_body(req, stream=False)
 
-    assert body["metadata"] == {"spend_logs_metadata": {"purpose": ""}}
+    assert body["metadata"] == {
+        "spend_logs_metadata": {"purpose": "", "country_code": ""}
+    }
 
 
 async def test_get_completion_sanitizes_response_surrogates(mocker):


### PR DESCRIPTION
service_type already rides in `user` on LiteLLM's spend log. This adds `purpose` too, via `metadata.spend_logs_metadata`, so we can filter spend by business purpose (chat, memory-generation, etc).

## Why JSON metadata over tags

LiteLLM also has native tags (`request_tags` column), that's the more "litellm-native" way and gets you built-in spend-by-tag reporting in their dashboard.

But that reporting is Enterprise-only, and we're on OSS. So tags would give us the raw column with none of the perks. On top of that, tags are flat strings (`purpose:chat`), so filtering in BQ means string parsing instead of a plain JSON key lookup. JSON metadata is simpler for us to query later, so we went with that.

## QA: 

New tests ✅ 
Local QA: 

```bash
docker exec litellm_postgres psql -U litellm -d litellm -x -c "SELECT metadata FROM \"LiteLLM_SpendLogs\" WHERE \"end_user\" = 'qa-purpose-test:memories';"
```

output has the "purpose"

```
metadata : {"status": null, "max_retries": 2, "batch_models": null, "usage_object": {"total_tokens": 30, "prompt_tokens": 10, "completion_tokens": 20, "prompt_tokens_details": null, "completion_tokens_details": null}, "user_api_key": "***", "cost_breakdown": {"input_cost": 0.0000022, "total_cost": 0.0000198, "output_cost": 0.0000176, "original_cost": 0.0000198, "margin_percent": 0.0, "discount_amount": 0.0, "tool_usage_cost": 0.0, "discount_percent": 0.0, "margin_fixed_amount": 0.0, "margin_total_amount": 0.0}, "eval_information": null, "attempted_retries": 0, "error_information": null, "applied_guardrails": [], "user_api_key_alias": "test-api", "spend_logs_metadata": {"purpose": "memory-generation"}, "user_api_key_org_id": null, "proxy_server_request": null, "requester_ip_address": "172.18.0.1", "user_api_key_team_id": null, "user_api_key_user_id": "default_user_id", "guardrail_information": null, "model_map_information": {"model_map_key": "mock", "model_map_value": null}, "mcp_tool_call_metadata": null, "additional_usage_values": {"prompt_tokens_details": null, "completion_tokens_details": null}, "cold_storage_object_key": null, "user_api_key_project_id": null, "user_api_key_team_alias": null, "litellm_overhead_time_ms": null, "user_api_key_project_alias": null, "vector_store_request_metadata": null}
```
